### PR TITLE
feat: implement NutritionBar component

### DIFF
--- a/.claude-output.json
+++ b/.claude-output.json
@@ -1,0 +1,11 @@
+{
+  "prTitle": "feat: implement NutritionBar component",
+  "prBody": "## Summary\n\n- Added `NutritionBar` component (`src/components/NutritionBar.tsx`) that renders a side-by-side visual bar comparison for a single nutrition metric between Starbucks and Costa drinks\n- Each bar is proportionally scaled so the higher value spans 100% of the available width\n- Winner highlighting: the brand with the better value (lower by default, configurable via `lowerIsBetter` prop) is bolded and styled in its brand colour\n- Tie state: neither brand is highlighted when values are equal\n- Accessibility: each bar is a `role=\"meter\"` element with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`\n- Supports `lowerIsBetter={false}` for nutrients like protein where higher is preferred\n- Added 12 tests covering rendering, winner logic, bar widths, tie state, and edge cases (zero values)\n- Updated `docs/components.md` with full NutritionBar API reference and usage examples\n\nCloses #65",
+  "testsPass": true,
+  "filesChanged": [
+    "src/components/NutritionBar.tsx",
+    "src/components/NutritionBar.test.tsx"
+  ],
+  "docsUpdated": ["docs/components.md"],
+  "docsReviewed": ["docs/concepts/costa-vs-starbucks/HLD.md", "README.md"]
+}

--- a/docs/components.md
+++ b/docs/components.md
@@ -71,6 +71,71 @@ Renders two brand sections, each containing a responsive grid of `DrinkCard` com
 
 ---
 
+---
+
+## NutritionBar
+
+**File:** `src/components/NutritionBar.tsx`
+
+Renders a side-by-side visual bar comparison for a single nutrition metric between a Starbucks and a Costa drink. Each bar is scaled proportionally so the brand with the higher value spans the full available width.
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Human-readable nutrient label, e.g. `"Calories"` |
+| `starbucksValue` | `number` | — | Starbucks drink's value for this nutrient |
+| `costaValue` | `number` | — | Costa drink's value for this nutrient |
+| `unit` | `string` | — | Unit appended to displayed values, e.g. `"kcal"`, `"g"`, `"mg"` |
+| `lowerIsBetter` | `boolean` | `true` | When `true`, the lower value is highlighted as the winner. Pass `false` for protein where higher is preferable. |
+
+### Features
+
+- Bar widths are scaled proportionally: the higher of the two values occupies 100% of the available width
+- Winner highlighting: the brand with the better value is bolded and coloured in its brand colour
+- Tie state: neither brand is highlighted when values are equal
+- Starbucks bar uses `bg-starbucks` (`#00704A`) / Costa bar uses `bg-costa` (`#6B1E1E`)
+- Each bar is rendered as a `role="meter"` element with `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` for accessibility
+- Zero-safe: when both values are 0, both bars render at 0% width without errors
+
+### Usage
+
+```tsx
+// Lower is better (calories, sugar, fat — default)
+<NutritionBar
+  label="Calories"
+  starbucksValue={160}
+  costaValue={144}
+  unit="kcal"
+/>
+
+// Higher is better (protein)
+<NutritionBar
+  label="Protein"
+  starbucksValue={9}
+  costaValue={8}
+  unit="g"
+  lowerIsBetter={false}
+/>
+```
+
+### Typical usage inside a ComparisonPanel
+
+```tsx
+import { NutritionBar } from './NutritionBar';
+
+// Render one row per nutrient
+<div className="flex flex-col gap-4">
+  <NutritionBar label="Calories"  starbucksValue={sbux.nutrition.calories_kcal} costaValue={costa.nutrition.calories_kcal} unit="kcal" />
+  <NutritionBar label="Sugar"     starbucksValue={sbux.nutrition.sugar_g}       costaValue={costa.nutrition.sugar_g}       unit="g" />
+  <NutritionBar label="Fat"       starbucksValue={sbux.nutrition.fat_g}         costaValue={costa.nutrition.fat_g}         unit="g" />
+  <NutritionBar label="Protein"   starbucksValue={sbux.nutrition.protein_g}     costaValue={costa.nutrition.protein_g}     unit="g"  lowerIsBetter={false} />
+  <NutritionBar label="Caffeine"  starbucksValue={sbux.nutrition.caffeine_mg}   costaValue={costa.nutrition.caffeine_mg}   unit="mg" />
+</div>
+```
+
+---
+
 ## TypeScript Types
 
 **File:** `src/types.ts`

--- a/src/components/NutritionBar.test.tsx
+++ b/src/components/NutritionBar.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NutritionBar } from './NutritionBar'
+
+describe('NutritionBar', () => {
+  it('renders the nutrient label', () => {
+    render(
+      <NutritionBar label="Calories" starbucksValue={160} costaValue={144} unit="kcal" />
+    )
+    expect(screen.getByText('Calories')).toBeInTheDocument()
+  })
+
+  it('renders both Starbucks and Costa brand labels', () => {
+    render(
+      <NutritionBar label="Sugar" starbucksValue={14} costaValue={12} unit="g" />
+    )
+    expect(screen.getByText('Starbucks')).toBeInTheDocument()
+    expect(screen.getByText('Costa')).toBeInTheDocument()
+  })
+
+  it('renders starbucks and costa values with unit', () => {
+    render(
+      <NutritionBar label="Calories" starbucksValue={160} costaValue={144} unit="kcal" />
+    )
+    expect(screen.getByText(/160 kcal/)).toBeInTheDocument()
+    expect(screen.getByText(/144 kcal/)).toBeInTheDocument()
+  })
+
+  it('renders two meter elements for the bars', () => {
+    render(
+      <NutritionBar label="Fat" starbucksValue={6} costaValue={8} unit="g" />
+    )
+    const meters = screen.getAllByRole('meter')
+    expect(meters).toHaveLength(2)
+  })
+
+  it('renders a data-testid="nutrition-bar" wrapper', () => {
+    render(
+      <NutritionBar label="Caffeine" starbucksValue={130} costaValue={185} unit="mg" />
+    )
+    expect(screen.getByTestId('nutrition-bar')).toBeInTheDocument()
+  })
+
+  it('highlights the lower starbucks value when lowerIsBetter (default)', () => {
+    render(
+      <NutritionBar label="Calories" starbucksValue={100} costaValue={200} unit="kcal" />
+    )
+    // The starbucks value text should have the winner (bold) class
+    const starbucksValueEl = screen.getByText(/100 kcal/)
+    expect(starbucksValueEl.className).toContain('font-bold')
+  })
+
+  it('highlights the lower costa value when lowerIsBetter (default)', () => {
+    render(
+      <NutritionBar label="Sugar" starbucksValue={20} costaValue={10} unit="g" />
+    )
+    const costaValueEl = screen.getByText(/10 g/)
+    expect(costaValueEl.className).toContain('font-bold')
+  })
+
+  it('highlights the higher starbucks value when lowerIsBetter=false (protein)', () => {
+    render(
+      <NutritionBar label="Protein" starbucksValue={9} costaValue={8} unit="g" lowerIsBetter={false} />
+    )
+    const starbucksValueEl = screen.getByText(/9 g/)
+    expect(starbucksValueEl.className).toContain('font-bold')
+  })
+
+  it('neither value is bolded on a tie', () => {
+    render(
+      <NutritionBar label="Fat" starbucksValue={5} costaValue={5} unit="g" />
+    )
+    // Both value spans should NOT contain the winner bold class
+    const valueEls = screen.getAllByText(/5 g/)
+    valueEls.forEach((el) => {
+      expect(el.className).not.toContain('font-bold')
+    })
+  })
+
+  it('sets starbucks bar width to 100% when starbucks has the higher value', () => {
+    const { container } = render(
+      <NutritionBar label="Calories" starbucksValue={200} costaValue={100} unit="kcal" />
+    )
+    const bars = container.querySelectorAll('[style]')
+    // First styled bar is starbucks (rendered first) — should be 100%
+    const sbuxBar = bars[0] as HTMLElement
+    expect(sbuxBar.style.width).toBe('100%')
+  })
+
+  it('sets bar width proportionally when values differ', () => {
+    const { container } = render(
+      <NutritionBar label="Calories" starbucksValue={200} costaValue={100} unit="kcal" />
+    )
+    const bars = container.querySelectorAll('[style]')
+    // Second styled bar is costa — should be 50%
+    const costaBar = bars[1] as HTMLElement
+    expect(costaBar.style.width).toBe('50%')
+  })
+
+  it('sets both bars to 0% when both values are 0', () => {
+    const { container } = render(
+      <NutritionBar label="Caffeine" starbucksValue={0} costaValue={0} unit="mg" />
+    )
+    const bars = container.querySelectorAll('[style]')
+    ;(Array.from(bars) as HTMLElement[]).forEach((bar) => {
+      expect(bar.style.width).toBe('0%')
+    })
+  })
+})

--- a/src/components/NutritionBar.tsx
+++ b/src/components/NutritionBar.tsx
@@ -1,0 +1,130 @@
+interface NutritionBarProps {
+  /** Human-readable label for this nutrient row, e.g. "Calories" */
+  label: string;
+  /** Starbucks drink's value for this nutrient */
+  starbucksValue: number;
+  /** Costa drink's value for this nutrient */
+  costaValue: number;
+  /** Unit string appended to the displayed value, e.g. "kcal", "g", "mg" */
+  unit: string;
+  /**
+   * Whether a lower value is considered better (default: true).
+   * When true, the brand with the lower value gets a "winner" highlight.
+   * Pass false for nutrients where higher is preferable (e.g. protein).
+   */
+  lowerIsBetter?: boolean;
+}
+
+const BRAND_COLORS = {
+  starbucks: {
+    bar: 'bg-starbucks',
+    winner: 'font-bold text-starbucks',
+    label: 'text-starbucks',
+  },
+  costa: {
+    bar: 'bg-costa',
+    winner: 'font-bold text-costa',
+    label: 'text-costa',
+  },
+} as const;
+
+function computeWidthPercent(value: number, maxValue: number): number {
+  if (maxValue === 0) return 0;
+  return Math.round((value / maxValue) * 100);
+}
+
+function getWinner(
+  starbucksValue: number,
+  costaValue: number,
+  lowerIsBetter: boolean,
+): 'starbucks' | 'costa' | 'tie' {
+  if (starbucksValue === costaValue) return 'tie';
+  if (lowerIsBetter) {
+    return starbucksValue < costaValue ? 'starbucks' : 'costa';
+  }
+  return starbucksValue > costaValue ? 'starbucks' : 'costa';
+}
+
+interface BarRowProps {
+  brand: 'starbucks' | 'costa';
+  value: number;
+  unit: string;
+  widthPercent: number;
+  isWinner: boolean;
+}
+
+function BarRow({ brand, value, unit, widthPercent, isWinner }: BarRowProps) {
+  const colors = BRAND_COLORS[brand];
+  const brandLabel = brand === 'starbucks' ? 'Starbucks' : 'Costa';
+
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={`w-20 shrink-0 text-xs text-right ${isWinner ? colors.winner : 'text-gray-600'}`}
+        aria-label={`${brandLabel}: ${value} ${unit}${isWinner ? ', lower' : ''}`}
+      >
+        {value} {unit}
+      </span>
+      <div
+        className="flex-1 h-4 bg-gray-100 rounded-full overflow-hidden"
+        role="meter"
+        aria-label={`${brandLabel} ${unit}`}
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-300 ${colors.bar}`}
+          style={{ width: `${widthPercent}%` }}
+        />
+      </div>
+      <span className={`w-20 shrink-0 text-xs ${colors.label} font-medium`}>
+        {brandLabel}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * NutritionBar renders a side-by-side visual bar comparison for a single
+ * nutrition metric between a Starbucks and a Costa drink.
+ *
+ * Each bar is scaled proportionally so the higher value spans the full
+ * available width. The brand with the better value is highlighted.
+ */
+export function NutritionBar({
+  label,
+  starbucksValue,
+  costaValue,
+  unit,
+  lowerIsBetter = true,
+}: NutritionBarProps) {
+  const maxValue = Math.max(starbucksValue, costaValue);
+  const sbuxWidth = computeWidthPercent(starbucksValue, maxValue);
+  const costaWidth = computeWidthPercent(costaValue, maxValue);
+  const winner = getWinner(starbucksValue, costaValue, lowerIsBetter);
+
+  return (
+    <div className="flex flex-col gap-1" data-testid="nutrition-bar">
+      <span className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
+        {label}
+      </span>
+      <BarRow
+        brand="starbucks"
+        value={starbucksValue}
+        unit={unit}
+        widthPercent={sbuxWidth}
+        isWinner={winner === 'starbucks'}
+      />
+      <BarRow
+        brand="costa"
+        value={costaValue}
+        unit={unit}
+        widthPercent={costaWidth}
+        isWinner={winner === 'costa'}
+      />
+    </div>
+  );
+}
+
+export default NutritionBar;


### PR DESCRIPTION
## Implementation Complete

## Summary

- Added `NutritionBar` component (`src/components/NutritionBar.tsx`) that renders a side-by-side visual bar comparison for a single nutrition metric between Starbucks and Costa drinks
- Each bar is proportionally scaled so the higher value spans 100% of the available width
- Winner highlighting: the brand with the better value (lower by default, configurable via `lowerIsBetter` prop) is bolded and styled in its brand colour
- Tie state: neither brand is highlighted when values are equal
- Accessibility: each bar is a `role="meter"` element with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`
- Supports `lowerIsBetter={false}` for nutrients like protein where higher is preferred
- Added 12 tests covering rendering, winner logic, bar widths, tie state, and edge cases (zero values)
- Updated `docs/components.md` with full NutritionBar API reference and usage examples

Closes #65

## Tasks Completed

- [x] Analyze the issue requirements
- [x] Implement the core changes
- [x] Add tests for new functionality
- [x] Update documentation if needed


---
**Issue:** #65 (Closes #65)
**Agent:** `frontend-engineer`
**Branch:** `feature/65-costa-vs-starbucks-sprint-2-issue-65`