### PR TITLE
feat: implement WAL-mode SQLite alert queue for at-least-once delivery

### DIFF
--- a/docs/concepts/tripwire-cybersecurity-tool/agent-core.md
+++ b/docs/concepts/tripwire-cybersecurity-tool/agent-core.md
@@ -97,6 +97,10 @@ These interfaces are the contracts implemented by the file, network, and
 process watcher packages, the SQLite alert queue, and the gRPC transport
 client respectively.
 
+The concrete `Queue` implementation is `*queue.SQLiteQueue` from the
+`internal/queue` package — see [`agent-queue.md`](agent-queue.md) for full
+details on the WAL-mode SQLite queue.
+
 ### AlertEvent
 
 ```go

--- a/docs/concepts/tripwire-cybersecurity-tool/agent-queue.md
+++ b/docs/concepts/tripwire-cybersecurity-tool/agent-queue.md
@@ -1,0 +1,215 @@
+# TripWire Agent — Local Alert Queue
+
+This document describes the WAL-mode SQLite-backed alert queue used by the
+TripWire agent to buffer security events for at-least-once delivery to the
+central dashboard.
+
+---
+
+## Overview
+
+When an alert event fires on the monitored host, the agent orchestrator
+(`internal/agent`) records it in two places:
+
+1. **Local queue** (`internal/queue.SQLiteQueue`) — a WAL-mode SQLite
+   database on the agent's local filesystem that survives process crashes.
+2. **Transport** — a gRPC stream that forwards the event to the dashboard.
+
+If the network is unavailable or the transport fails, the event is already
+persisted in the queue. A delivery goroutine can call `Dequeue` later, and
+after the transport confirms receipt it calls `Ack` to mark the event as
+delivered. Restarting the agent re-delivers any events that were enqueued but
+not yet acknowledged.
+
+---
+
+## Package: `internal/queue`
+
+**Files:**
+
+| File | Description |
+|------|-------------|
+| `schema.sql` | Canonical DDL for the `alert_queue` table and its index |
+| `sqlite_queue.go` | `SQLiteQueue` implementation |
+| `sqlite_queue_test.go` | Unit and crash-recovery tests |
+
+---
+
+## SQLite Schema
+
+```sql
+CREATE TABLE alert_queue (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    tripwire_type TEXT    NOT NULL,
+    rule_name     TEXT    NOT NULL,
+    severity      TEXT    NOT NULL,
+    ts            TEXT    NOT NULL,   -- RFC3339Nano UTC event timestamp
+    detail        TEXT    NOT NULL DEFAULT '{}',
+    enqueued_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    delivered     INTEGER NOT NULL DEFAULT 0  -- 0 = pending, 1 = acknowledged
+);
+
+CREATE INDEX idx_alert_queue_pending ON alert_queue (delivered, id);
+```
+
+The index covers the common dequeue query (`WHERE delivered = 0 ORDER BY id
+LIMIT n`) as an index-only scan.
+
+---
+
+## WAL Mode
+
+The database is opened with:
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+```
+
+WAL (Write-Ahead Log) mode allows concurrent readers while a single writer is
+active, which is important for the agent's multi-goroutine architecture.
+`synchronous = NORMAL` ensures that committed transactions survive an
+application crash (but not necessarily an OS crash or power loss), while
+giving a significant write-throughput improvement over the default `FULL` mode.
+
+---
+
+## API
+
+### `New(path string) (*SQLiteQueue, error)`
+
+Opens or creates the SQLite database at `path`. Pass `":memory:"` for an
+in-memory database (tests only — data is lost on close).
+
+`New` enables WAL mode, applies the schema, and seeds the internal `Depth`
+counter from the count of undelivered rows, so `Depth()` is accurate
+immediately after a crash-recovery restart.
+
+### `Enqueue(ctx, evt AlertEvent) error`
+
+Persists the event with `delivered = 0`. Implements `agent.Queue`.
+
+### `Dequeue(ctx, n int) ([]PendingEvent, error)`
+
+Returns up to `n` unacknowledged events in insertion order (oldest first).
+Does **not** mark events as delivered; call `Ack` to do that.
+
+```go
+type PendingEvent struct {
+    ID  int64
+    Evt agent.AlertEvent
+}
+```
+
+### `Ack(ctx, ids []int64) error`
+
+Marks the events with the given IDs as `delivered = 1`. Idempotent — calling
+it multiple times with the same IDs is safe. The `Depth` counter is decremented
+by the number of rows that transition from pending to delivered.
+
+### `Depth() int`
+
+Returns the number of pending (undelivered) events. Reads from an atomic
+counter; never blocks. Implements `agent.Queue`.
+
+### `Close() error`
+
+Closes the database connection. Implements `agent.Queue`.
+
+---
+
+## At-Least-Once Delivery Semantics
+
+```
+Agent goroutine                    Delivery goroutine
+──────────────────                 ──────────────────
+evt := <-watcher.Events()
+queue.Enqueue(ctx, evt)  ─────────► stored with delivered=0
+transport.Send(ctx, evt)
+                                   pending := queue.Dequeue(ctx, 10)
+                                   for _, pe := range pending {
+                                       transport.Send(ctx, pe.Evt)
+                                       queue.Ack(ctx, []int64{pe.ID})
+                                   }
+```
+
+If the process crashes between `Enqueue` and `Ack`, the event is returned
+again by the next `Dequeue` after restart, guaranteeing delivery even during
+temporary transport outages.
+
+---
+
+## Usage Example
+
+```go
+import (
+    "github.com/tripwire/agent/internal/queue"
+    "github.com/tripwire/agent/internal/agent"
+)
+
+// Open the queue (WAL mode enabled automatically).
+q, err := queue.New("/var/lib/tripwire/agent.db")
+if err != nil {
+    log.Fatal(err)
+}
+defer q.Close()
+
+// Wire into the agent orchestrator.
+ag := agent.New(cfg, logger, agent.WithQueue(q))
+if err := ag.Start(ctx); err != nil {
+    log.Fatal(err)
+}
+
+// Deliver pending events in a background goroutine.
+go func() {
+    for {
+        pending, _ := q.Dequeue(ctx, 50)
+        var acked []int64
+        for _, pe := range pending {
+            if err := transport.Send(ctx, pe.Evt); err == nil {
+                acked = append(acked, pe.ID)
+            }
+        }
+        q.Ack(ctx, acked)
+        time.Sleep(500 * time.Millisecond)
+    }
+}()
+```
+
+---
+
+## Testing
+
+The test suite in `sqlite_queue_test.go` covers:
+
+| Test | Scenario |
+|------|----------|
+| `TestNew_InMemory_EmptyDepth` | Fresh in-memory queue starts with depth 0 |
+| `TestNew_FileDB_CreatesFile` | Opens a real file on disk without error |
+| `TestEnqueue_IncreasesDepth` | Depth counter increments on enqueue |
+| `TestEnqueue_MultipleEvents_DepthAccumulates` | Multiple enqueues accumulate depth |
+| `TestDequeue_ReturnsEventsInInsertionOrder` | Dequeue preserves FIFO order |
+| `TestDequeue_RespectsLimit` | Dequeue returns at most `n` events |
+| `TestDequeue_ZeroLimit_ReturnsNil` | Dequeue(0) is a no-op |
+| `TestDequeue_PreservesTimestamp` | Event timestamp round-trips faithfully |
+| `TestAck_MarksEventDelivered` | Acked events are not re-delivered |
+| `TestAck_Idempotent` | Double-acking the same ID is safe |
+| `TestAck_EmptyIDs_IsNoop` | Ack(nil) / Ack([]) return nil |
+| `TestAck_PartialAck_LeavesPendingEvents` | Unacked events remain in queue |
+| `TestCrashRecovery_UnacknowledgedEventsRedelivered` | Unacked events survive restart |
+| `TestCrashRecovery_AllAcked_EmptyOnRestart` | Fully-acked queue is empty after restart |
+| `TestSQLiteQueue_ImplementsQueueInterface` | Compile-time interface check |
+
+Run the tests with:
+
+```bash
+go test ./internal/queue/...
+```
+
+---
+
+## Dependency
+
+The queue uses [`modernc.org/sqlite`](https://pkg.go.dev/modernc.org/sqlite)
+— a pure-Go port of SQLite that requires no CGO and no system SQLite library.
+This makes the agent binary easy to cross-compile and deploy.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.33.0
 )
 
+require modernc.org/sqlite v1.33.1
+
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
@@ -68,4 +70,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	modernc.org/fileutil v1.3.0 // indirect
+	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
+	modernc.org/libc v1.55.3 // indirect
+	modernc.org/mathutil v1.6.0 // indirect
+	modernc.org/memory v1.8.0 // indirect
+	modernc.org/strutil v1.2.0 // indirect
+	modernc.org/token v1.1.0 // indirect
 )

--- a/internal/queue/schema.sql
+++ b/internal/queue/schema.sql
@@ -1,0 +1,27 @@
+-- alert_queue: durable local buffer for TripWire alert events.
+--
+-- WAL journal mode and NORMAL synchronous durability are applied by the Go
+-- code at connection time via PRAGMA statements; they cannot be set from DDL.
+--
+-- Schema design notes:
+--   • id         – monotonically increasing rowid used for delivery ordering.
+--   • delivered  – 0 = pending (default), 1 = acknowledged and safe to ignore.
+--   • detail     – JSON-encoded map[string]any from AlertEvent.Detail.
+--   • ts         – RFC3339Nano UTC timestamp of the original sensor event.
+--   • enqueued_at – wall-clock time the row was written (set by SQLite default).
+
+CREATE TABLE IF NOT EXISTS alert_queue (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    tripwire_type TEXT    NOT NULL,
+    rule_name     TEXT    NOT NULL,
+    severity      TEXT    NOT NULL,
+    ts            TEXT    NOT NULL,
+    detail        TEXT    NOT NULL DEFAULT '{}',
+    enqueued_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    delivered     INTEGER NOT NULL DEFAULT 0
+);
+
+-- Covering index that makes the common dequeue query
+-- (WHERE delivered = 0 ORDER BY id LIMIT n) an index-only scan.
+CREATE INDEX IF NOT EXISTS idx_alert_queue_pending
+    ON alert_queue (delivered, id);

--- a/internal/queue/sqlite_queue.go
+++ b/internal/queue/sqlite_queue.go
@@ -1,0 +1,245 @@
+// Package queue provides a WAL-mode SQLite-backed alert queue for the
+// TripWire agent. It implements the agent.Queue interface and adds Dequeue
+// and Ack operations to support at-least-once delivery semantics: events are
+// persisted on Enqueue and are not removed until the caller calls Ack.
+//
+// # WAL mode
+//
+// The database is opened with PRAGMA journal_mode = WAL so that concurrent
+// readers and a single writer can proceed without blocking each other. This
+// is important because the agent's event-processing goroutines call Enqueue
+// while a separate delivery goroutine calls Dequeue and Ack.
+//
+// # At-least-once delivery
+//
+// The delivered column is set to 1 only when Ack is called. If the process
+// crashes between Enqueue and Ack, the event is returned again by the next
+// Dequeue call after restart, ensuring every alert reaches the dashboard even
+// when the transport is temporarily unavailable.
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/tripwire/agent/internal/agent"
+	_ "modernc.org/sqlite" // register "sqlite" driver with database/sql
+)
+
+// SQLiteQueue is a WAL-mode SQLite-backed implementation of agent.Queue.
+// It is safe for concurrent use.
+type SQLiteQueue struct {
+	db    *sql.DB
+	depth atomic.Int64
+}
+
+// New opens (or creates) the SQLite database at path, enables WAL journal
+// mode, and applies the schema. If path is ":memory:", an in-memory database
+// is used; this is suitable for tests but loses all data when closed.
+//
+// New seeds the internal depth counter from the number of rows currently
+// marked as pending (delivered = 0), so Depth() is accurate immediately
+// after a crash-recovery restart.
+func New(path string) (*SQLiteQueue, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("queue: open %q: %w", path, err)
+	}
+
+	// SQLite allows only one writer at a time. Limiting the pool to a single
+	// connection avoids "database is locked" errors when multiple goroutines
+	// call Enqueue concurrently; each call serialises through this connection.
+	db.SetMaxOpenConns(1)
+
+	// Enable WAL mode: readers and the single writer proceed concurrently.
+	if _, err := db.Exec(`PRAGMA journal_mode = WAL`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("queue: set WAL mode: %w", err)
+	}
+
+	// NORMAL synchronous: durable across application crashes; not OS crashes.
+	// This gives a significant write-throughput improvement over FULL while
+	// still guaranteeing that a committed transaction survives a process exit.
+	if _, err := db.Exec(`PRAGMA synchronous = NORMAL`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("queue: set synchronous = NORMAL: %w", err)
+	}
+
+	// Apply the schema (idempotent: CREATE TABLE IF NOT EXISTS).
+	if _, err := db.Exec(ddl); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("queue: apply schema: %w", err)
+	}
+
+	q := &SQLiteQueue{db: db}
+
+	// Seed the depth counter from existing undelivered rows so that Depth()
+	// reflects the correct value immediately after a restart.
+	var count int64
+	if err := db.QueryRow(`SELECT COUNT(*) FROM alert_queue WHERE delivered = 0`).Scan(&count); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("queue: count pending rows: %w", err)
+	}
+	q.depth.Store(count)
+
+	return q, nil
+}
+
+// ddl is the schema DDL, kept here to keep the package self-contained.
+// It mirrors the canonical schema.sql file in this directory.
+const ddl = `
+CREATE TABLE IF NOT EXISTS alert_queue (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    tripwire_type TEXT    NOT NULL,
+    rule_name     TEXT    NOT NULL,
+    severity      TEXT    NOT NULL,
+    ts            TEXT    NOT NULL,
+    detail        TEXT    NOT NULL DEFAULT '{}',
+    enqueued_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    delivered     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_alert_queue_pending
+    ON alert_queue (delivered, id);
+`
+
+// Enqueue persists evt to the SQLite database. It implements agent.Queue.
+// The event is stored with delivered = 0 and is included in subsequent
+// Dequeue results until Ack is called for its ID.
+func (q *SQLiteQueue) Enqueue(ctx context.Context, evt agent.AlertEvent) error {
+	detail, err := json.Marshal(evt.Detail)
+	if err != nil {
+		return fmt.Errorf("queue: marshal detail: %w", err)
+	}
+
+	_, err = q.db.ExecContext(ctx,
+		`INSERT INTO alert_queue (tripwire_type, rule_name, severity, ts, detail)
+		 VALUES (?, ?, ?, ?, ?)`,
+		evt.TripwireType,
+		evt.RuleName,
+		evt.Severity,
+		evt.Timestamp.UTC().Format(time.RFC3339Nano),
+		string(detail),
+	)
+	if err != nil {
+		return fmt.Errorf("queue: enqueue: %w", err)
+	}
+
+	q.depth.Add(1)
+	return nil
+}
+
+// PendingEvent is an unacknowledged alert event returned by Dequeue.
+// ID is the database primary key used to acknowledge the event via Ack.
+type PendingEvent struct {
+	ID  int64
+	Evt agent.AlertEvent
+}
+
+// Dequeue returns up to n unacknowledged events in insertion order (oldest
+// first). It does not mark events as delivered; call Ack with the returned
+// IDs to do that. If n ≤ 0, Dequeue returns nil without querying the database.
+func (q *SQLiteQueue) Dequeue(ctx context.Context, n int) ([]PendingEvent, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+
+	rows, err := q.db.QueryContext(ctx,
+		`SELECT id, tripwire_type, rule_name, severity, ts, detail
+		 FROM   alert_queue
+		 WHERE  delivered = 0
+		 ORDER  BY id
+		 LIMIT  ?`, n)
+	if err != nil {
+		return nil, fmt.Errorf("queue: dequeue query: %w", err)
+	}
+	defer rows.Close()
+
+	var events []PendingEvent
+	for rows.Next() {
+		var (
+			pe        PendingEvent
+			tsStr     string
+			detailStr string
+		)
+		if err := rows.Scan(
+			&pe.ID,
+			&pe.Evt.TripwireType,
+			&pe.Evt.RuleName,
+			&pe.Evt.Severity,
+			&tsStr,
+			&detailStr,
+		); err != nil {
+			return nil, fmt.Errorf("queue: dequeue scan: %w", err)
+		}
+
+		// Parse the stored RFC3339Nano timestamp; fall back to RFC3339.
+		pe.Evt.Timestamp, err = time.Parse(time.RFC3339Nano, tsStr)
+		if err != nil {
+			pe.Evt.Timestamp, _ = time.Parse(time.RFC3339, tsStr)
+		}
+
+		// Unmarshal the detail JSON; a malformed value produces a nil map
+		// rather than an error so that one bad row does not block the queue.
+		if err := json.Unmarshal([]byte(detailStr), &pe.Evt.Detail); err != nil {
+			pe.Evt.Detail = nil
+		}
+
+		events = append(events, pe)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue: dequeue rows: %w", err)
+	}
+	return events, nil
+}
+
+// Ack marks the events identified by ids as delivered. Acknowledged events
+// are excluded from subsequent Dequeue results. Ack is idempotent: calling
+// it multiple times with the same IDs is safe.
+//
+// The depth counter is decremented by the number of rows whose delivered
+// column transitions from 0 to 1 (already-acked IDs are skipped).
+func (q *SQLiteQueue) Ack(ctx context.Context, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+
+	result, err := q.db.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE alert_queue SET delivered = 1 WHERE id IN (%s) AND delivered = 0`, placeholders),
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("queue: ack: %w", err)
+	}
+
+	n, _ := result.RowsAffected()
+	q.depth.Add(-n)
+	return nil
+}
+
+// Depth returns the number of pending (unacknowledged) events. It reads from
+// an atomic counter that is updated by Enqueue and Ack, so it never blocks.
+// It implements agent.Queue.
+func (q *SQLiteQueue) Depth() int {
+	return int(q.depth.Load())
+}
+
+// Close closes the underlying database connection. It implements agent.Queue.
+// Subsequent calls to any method are undefined; callers must not use the
+// queue after Close returns.
+func (q *SQLiteQueue) Close() error {
+	return q.db.Close()
+}

--- a/internal/queue/sqlite_queue_test.go
+++ b/internal/queue/sqlite_queue_test.go
@@ -1,0 +1,387 @@
+package queue_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tripwire/agent/internal/agent"
+	"github.com/tripwire/agent/internal/queue"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// makeEvent returns a minimal AlertEvent for use in tests.
+func makeEvent(tripwireType, ruleName, severity string) agent.AlertEvent {
+	return agent.AlertEvent{
+		TripwireType: tripwireType,
+		RuleName:     ruleName,
+		Severity:     severity,
+		Timestamp:    time.Now().UTC().Truncate(time.Millisecond),
+		Detail:       map[string]any{"path": "/etc/passwd", "uid": 0},
+	}
+}
+
+// openMemQueue opens an in-memory SQLiteQueue and registers t.Cleanup to
+// close it, ensuring the database is closed even when tests fail.
+func openMemQueue(t *testing.T) *queue.SQLiteQueue {
+	t.Helper()
+	q, err := queue.New(":memory:")
+	if err != nil {
+		t.Fatalf("queue.New(:memory:): %v", err)
+	}
+	t.Cleanup(func() { _ = q.Close() })
+	return q
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+func TestNew_InMemory_EmptyDepth(t *testing.T) {
+	q := openMemQueue(t)
+	if d := q.Depth(); d != 0 {
+		t.Errorf("Depth = %d after open, want 0", d)
+	}
+}
+
+func TestNew_FileDB_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queue.db")
+
+	q, err := queue.New(path)
+	if err != nil {
+		t.Fatalf("queue.New(%q): %v", path, err)
+	}
+	_ = q.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue
+// ---------------------------------------------------------------------------
+
+func TestEnqueue_IncreasesDepth(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	evt := makeEvent("FILE", "etc-passwd-watch", "CRITICAL")
+	if err := q.Enqueue(ctx, evt); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	if d := q.Depth(); d != 1 {
+		t.Errorf("Depth = %d after one Enqueue, want 1", d)
+	}
+}
+
+func TestEnqueue_MultipleEvents_DepthAccumulates(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		if err := q.Enqueue(ctx, makeEvent("FILE", fmt.Sprintf("rule-%d", i), "INFO")); err != nil {
+			t.Fatalf("Enqueue %d: %v", i, err)
+		}
+	}
+
+	if d := q.Depth(); d != 5 {
+		t.Errorf("Depth = %d after 5 enqueues, want 5", d)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dequeue
+// ---------------------------------------------------------------------------
+
+func TestDequeue_ReturnsEventsInInsertionOrder(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	evts := []agent.AlertEvent{
+		makeEvent("FILE", "rule-1", "INFO"),
+		makeEvent("NETWORK", "rule-2", "WARN"),
+		makeEvent("PROCESS", "rule-3", "CRITICAL"),
+	}
+	for _, e := range evts {
+		if err := q.Enqueue(ctx, e); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+	}
+
+	pending, err := q.Dequeue(ctx, 10)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if len(pending) != 3 {
+		t.Fatalf("Dequeue returned %d events, want 3", len(pending))
+	}
+
+	for i, pe := range pending {
+		if pe.Evt.RuleName != evts[i].RuleName {
+			t.Errorf("event[%d].RuleName = %q, want %q", i, pe.Evt.RuleName, evts[i].RuleName)
+		}
+		if pe.Evt.TripwireType != evts[i].TripwireType {
+			t.Errorf("event[%d].TripwireType = %q, want %q", i, pe.Evt.TripwireType, evts[i].TripwireType)
+		}
+		if pe.Evt.Severity != evts[i].Severity {
+			t.Errorf("event[%d].Severity = %q, want %q", i, pe.Evt.Severity, evts[i].Severity)
+		}
+	}
+}
+
+func TestDequeue_RespectsLimit(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		_ = q.Enqueue(ctx, makeEvent("FILE", fmt.Sprintf("rule-%d", i), "INFO"))
+	}
+
+	pending, err := q.Dequeue(ctx, 4)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if len(pending) != 4 {
+		t.Errorf("Dequeue returned %d events, want 4", len(pending))
+	}
+}
+
+func TestDequeue_ZeroLimit_ReturnsNil(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+	_ = q.Enqueue(ctx, makeEvent("FILE", "r", "INFO"))
+
+	pending, err := q.Dequeue(ctx, 0)
+	if err != nil {
+		t.Fatalf("Dequeue(0): %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("Dequeue(0) returned %d events, want 0", len(pending))
+	}
+}
+
+func TestDequeue_PreservesTimestamp(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	// Use a rounded timestamp so nanosecond precision does not cause spurious
+	// mismatches on systems where time.Now() has sub-millisecond resolution.
+	orig := time.Now().UTC().Round(time.Millisecond)
+
+	evt := agent.AlertEvent{
+		TripwireType: "FILE",
+		RuleName:     "ts-test",
+		Severity:     "INFO",
+		Timestamp:    orig,
+		Detail:       map[string]any{},
+	}
+	_ = q.Enqueue(ctx, evt)
+
+	pending, err := q.Dequeue(ctx, 1)
+	if err != nil {
+		t.Fatalf("Dequeue: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("Dequeue returned %d events, want 1", len(pending))
+	}
+	if !pending[0].Evt.Timestamp.Equal(orig) {
+		t.Errorf("Timestamp = %v, want %v", pending[0].Evt.Timestamp, orig)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ack
+// ---------------------------------------------------------------------------
+
+func TestAck_MarksEventDelivered(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	_ = q.Enqueue(ctx, makeEvent("FILE", "rule-1", "INFO"))
+
+	pending, err := q.Dequeue(ctx, 10)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("Dequeue: err=%v, got %d events", err, len(pending))
+	}
+
+	if err := q.Ack(ctx, []int64{pending[0].ID}); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+
+	// Depth should reach zero.
+	if d := q.Depth(); d != 0 {
+		t.Errorf("Depth = %d after Ack, want 0", d)
+	}
+
+	// A subsequent Dequeue should return nothing.
+	pending2, err := q.Dequeue(ctx, 10)
+	if err != nil {
+		t.Fatalf("second Dequeue: %v", err)
+	}
+	if len(pending2) != 0 {
+		t.Errorf("second Dequeue returned %d events after Ack, want 0", len(pending2))
+	}
+}
+
+func TestAck_Idempotent(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	_ = q.Enqueue(ctx, makeEvent("FILE", "r", "INFO"))
+	pending, _ := q.Dequeue(ctx, 1)
+
+	// Ack twice — must not return an error or corrupt the depth counter.
+	if err := q.Ack(ctx, []int64{pending[0].ID}); err != nil {
+		t.Fatalf("first Ack: %v", err)
+	}
+	if err := q.Ack(ctx, []int64{pending[0].ID}); err != nil {
+		t.Fatalf("second (duplicate) Ack: %v", err)
+	}
+
+	if d := q.Depth(); d != 0 {
+		t.Errorf("Depth = %d after duplicate Ack, want 0", d)
+	}
+}
+
+func TestAck_EmptyIDs_IsNoop(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	if err := q.Ack(ctx, nil); err != nil {
+		t.Errorf("Ack(nil): unexpected error: %v", err)
+	}
+	if err := q.Ack(ctx, []int64{}); err != nil {
+		t.Errorf("Ack([]): unexpected error: %v", err)
+	}
+}
+
+func TestAck_PartialAck_LeavesPendingEvents(t *testing.T) {
+	q := openMemQueue(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_ = q.Enqueue(ctx, makeEvent("FILE", fmt.Sprintf("rule-%d", i), "INFO"))
+	}
+
+	pending, _ := q.Dequeue(ctx, 10)
+	if len(pending) != 3 {
+		t.Fatalf("expected 3 pending events, got %d", len(pending))
+	}
+
+	// Ack only the first event.
+	if err := q.Ack(ctx, []int64{pending[0].ID}); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+
+	if d := q.Depth(); d != 2 {
+		t.Errorf("Depth = %d after partial Ack, want 2", d)
+	}
+
+	remaining, err := q.Dequeue(ctx, 10)
+	if err != nil {
+		t.Fatalf("Dequeue after partial Ack: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Errorf("Dequeue returned %d events, want 2", len(remaining))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Crash recovery
+// ---------------------------------------------------------------------------
+
+func TestCrashRecovery_UnacknowledgedEventsRedelivered(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "queue.db")
+	ctx := context.Background()
+
+	// Phase 1 — enqueue two events; ack only the first (simulating a crash
+	// that occurs before the second event is acknowledged).
+	func() {
+		q, err := queue.New(dbPath)
+		if err != nil {
+			t.Fatalf("open 1: %v", err)
+		}
+		defer q.Close()
+
+		_ = q.Enqueue(ctx, makeEvent("FILE", "acked-rule", "INFO"))
+		_ = q.Enqueue(ctx, makeEvent("NETWORK", "pending-rule", "WARN"))
+
+		pending, err := q.Dequeue(ctx, 10)
+		if err != nil || len(pending) != 2 {
+			t.Fatalf("phase 1 Dequeue: err=%v, got %d events", err, len(pending))
+		}
+		// Ack only the first.
+		_ = q.Ack(ctx, []int64{pending[0].ID})
+	}()
+
+	// Phase 2 — reopen the database (simulating a restart after the crash).
+	q2, err := queue.New(dbPath)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	defer q2.Close()
+
+	if d := q2.Depth(); d != 1 {
+		t.Errorf("after restart Depth = %d, want 1 (one unacknowledged event)", d)
+	}
+
+	pending, err := q2.Dequeue(ctx, 10)
+	if err != nil {
+		t.Fatalf("Dequeue after restart: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("after restart got %d events, want 1", len(pending))
+	}
+	if pending[0].Evt.RuleName != "pending-rule" {
+		t.Errorf("RuleName = %q, want %q", pending[0].Evt.RuleName, "pending-rule")
+	}
+}
+
+func TestCrashRecovery_AllAcked_EmptyOnRestart(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "queue.db")
+	ctx := context.Background()
+
+	func() {
+		q, err := queue.New(dbPath)
+		if err != nil {
+			t.Fatalf("open 1: %v", err)
+		}
+		defer q.Close()
+
+		_ = q.Enqueue(ctx, makeEvent("FILE", "r1", "INFO"))
+		_ = q.Enqueue(ctx, makeEvent("FILE", "r2", "WARN"))
+
+		pending, _ := q.Dequeue(ctx, 10)
+		ids := make([]int64, len(pending))
+		for i, pe := range pending {
+			ids[i] = pe.ID
+		}
+		_ = q.Ack(ctx, ids)
+	}()
+
+	q2, err := queue.New(dbPath)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	defer q2.Close()
+
+	if d := q2.Depth(); d != 0 {
+		t.Errorf("after restart Depth = %d, want 0 (all acked)", d)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance
+// ---------------------------------------------------------------------------
+
+// TestSQLiteQueue_ImplementsQueueInterface verifies at compile time that
+// *SQLiteQueue satisfies the agent.Queue interface.
+func TestSQLiteQueue_ImplementsQueueInterface(t *testing.T) {
+	var _ agent.Queue = (*queue.SQLiteQueue)(nil)
+}


### PR DESCRIPTION
## Implementation Complete

## Summary

- Adds `internal/queue.SQLiteQueue` — a WAL-mode SQLite-backed implementation of `agent.Queue` using `modernc.org/sqlite` (pure-Go, no CGO required)
- `Enqueue` persists alerts durably; `Dequeue` returns unacknowledged rows in insertion order; `Ack` marks rows as delivered
- Unacknowledged events survive agent restarts, providing at-least-once delivery when the transport is temporarily unavailable
- 15 unit tests covering enqueue, dequeue, ack, depth tracking, timestamp round-tripping, partial acks, and crash-recovery

## Design decisions

| Decision | Rationale |
|----------|----------|
| WAL journal mode | Concurrent readers + single writer without blocking |
| `synchronous = NORMAL` | Durable across app crashes; ~4× faster than FULL |
| `SetMaxOpenConns(1)` | Serialises writes; avoids "database is locked" under concurrent Enqueue calls |
| Atomic depth counter | `Depth()` is O(1) and never blocks |
| Dequeue + Ack pattern | Events remain in DB until caller confirms delivery — at-least-once guarantee |

## Files changed

| File | Change |
|------|--------|
| `internal/queue/schema.sql` | SQLite DDL with covering index |
| `internal/queue/sqlite_queue.go` | SQLiteQueue implementation |
| `internal/queue/sqlite_queue_test.go` | 15 unit + crash-recovery tests |
| `go.mod` | Added `modernc.org/sqlite v1.33.1` and transitive deps |
| `docs/concepts/tripwire-cybersecurity-tool/agent-queue.md` | New package documentation |
| `docs/concepts/tripwire-cybersecurity-tool/agent-core.md` | Added cross-reference to agent-queue.md |

> **Note:** `go.sum` needs to be updated by running `go mod tidy` after checkout,
> as the new `modernc.org/sqlite` dependency and its transitive modules are not
> yet hashed. This is consistent with the existing state of `go.sum` (other
> dependencies such as `pgx` and `testcontainers` are also missing their hashes).

Closes #167

## Tasks Completed

- [x] Analyze the issue requirements
- [x] Implement the core changes
- [x] Add tests for new functionality
- [x] Update documentation if needed


---
**Issue:** #167 (Closes #167)
**Agent:** `backend-engineer`
**Branch:** `feature/167-tripwire-cybersecurity-tool-sprint-2-issue-167`