### PR TITLE
feat: implement DispositionEngine rule evaluation with fail-secure default

### DIFF
--- a/docs/concepts/fileguard/disposition-engine.md
+++ b/docs/concepts/fileguard/disposition-engine.md
@@ -1,0 +1,227 @@
+# DispositionEngine
+
+**Module:** `fileguard.core.disposition`
+**Status:** Implemented (Sprint 4)
+
+---
+
+## Overview
+
+The `DispositionEngine` evaluates AV and PII findings accumulated in a
+`ScanContext` against per-tenant, per-file-type disposition rules and
+produces a final `DispositionResult` of **block**, **quarantine**, or
+**pass** (with optional flags).
+
+**Design principles:**
+
+| Principle | Implementation |
+|---|---|
+| Fail-secure | Any unhandled exception during evaluation always results in `block`; a file is never silently passed through on error |
+| Configurable per-tenant | Rules stored as JSONB in `TenantConfig.disposition_rules`; evaluated at scan time without restart |
+| Per-MIME-type overrides | `mime_type_overrides` map lets tenants configure different actions for specific file types |
+| Quarantine delegation | Quarantine storage is delegated to an injectable `QuarantineService`; absent or failing service falls back to `block` |
+| Stateless | The same `DispositionEngine` instance can be used concurrently from multiple asyncio tasks |
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `fileguard/core/disposition.py` | `DispositionEngine`, `DispositionResult`, `QuarantineService` interface, `QuarantineError` |
+| `fileguard/tests/test_disposition.py` | Full unit test suite covering all disposition outcomes and edge cases |
+
+---
+
+## Disposition Rule Schema
+
+Rules are stored as JSONB in `TenantConfig.disposition_rules` and resolved at scan time.
+
+```json
+{
+    "on_error":     "block",
+    "on_av_threat": "block",
+    "on_pii":       "pass",
+    "mime_type_overrides": {
+        "application/pdf": {
+            "on_pii": "quarantine"
+        }
+    }
+}
+```
+
+### Rule Keys
+
+| Key | Description | Valid Values | Default |
+|---|---|---|---|
+| `on_error` | Action when `context.errors` is non-empty | `"block"`, `"quarantine"`, `"pass"` | `"block"` |
+| `on_av_threat` | Action when AV-threat findings are present | `"block"`, `"quarantine"`, `"pass"` | `"block"` |
+| `on_pii` | Action when PII findings are present | `"block"`, `"quarantine"`, `"pass"` | `"pass"` |
+| `mime_type_overrides` | Per-MIME-type rule overrides (applied before top-level rules) | Object keyed by MIME type | `{}` |
+
+All keys are optional. Built-in defaults apply whenever a key is absent or contains an invalid value.
+
+### Rule Resolution Order
+
+For each rule key (`on_error`, `on_av_threat`, `on_pii`), the engine resolves the action as follows:
+
+1. **MIME-type override** — `rules["mime_type_overrides"][mime_type][rule_key]`
+2. **Top-level rule** — `rules[rule_key]`
+3. **Built-in default** — see table above
+
+Invalid action values (anything other than `"block"`, `"quarantine"`, `"pass"`) are silently ignored and the next level is tried.
+
+---
+
+## Evaluation Priority
+
+Within a scan context, conditions are evaluated in this priority order:
+
+1. **Scan errors** (`context.errors` non-empty) — highest priority; applies `on_error` rule
+2. **AV-threat findings** — applies `on_av_threat` rule
+3. **PII findings** — applies `on_pii` rule
+4. **No findings** — clean pass, `action="pass"`, `status="clean"`
+
+---
+
+## Disposition Actions and Status
+
+| Action | Status | When |
+|---|---|---|
+| `"pass"` | `"clean"` | No findings, no errors |
+| `"pass"` | `"flagged"` | Findings present but rule says `"pass"` (pass-with-flags) |
+| `"block"` | `"rejected"` | Rule says `"block"`, or fail-secure triggered |
+| `"quarantine"` | `"rejected"` | Rule says `"quarantine"` and `QuarantineService` succeeds |
+
+---
+
+## Classes
+
+### `DispositionEngine`
+
+```python
+class DispositionEngine:
+    def __init__(
+        self,
+        quarantine_service: QuarantineService | None = None,
+    ) -> None: ...
+
+    async def decide(
+        self,
+        context: ScanContext,
+        rules: dict[str, Any] | None = None,
+    ) -> DispositionResult: ...
+```
+
+The engine is constructed once and reused across scans. Inject a
+`QuarantineService` to enable quarantine actions; omit it to fall back
+to block on quarantine decisions.
+
+#### `decide(context, rules)`
+
+Primary pipeline entry point. Reads `context.findings` and `context.errors`,
+resolves the applicable rules, and returns an immutable `DispositionResult`.
+
+**Fail-secure:** any unhandled exception is caught, logged, and produces a
+`block` outcome. The exception message is included in `result.reasons`.
+
+### `DispositionResult`
+
+Immutable frozen dataclass returned by `DispositionEngine.decide()`.
+
+```python
+@dataclass(frozen=True)
+class DispositionResult:
+    action: Literal["pass", "quarantine", "block"]
+    status: Literal["clean", "flagged", "rejected"]
+    quarantine_ref: str | None        # set when action == "quarantine"
+    reasons: list[str]                # human-readable decision trail
+```
+
+### `QuarantineService`
+
+Abstract base class that must be implemented by quarantine storage backends.
+
+```python
+class QuarantineService(ABC):
+    @abstractmethod
+    async def store(self, context: ScanContext) -> str: ...
+```
+
+`store()` must:
+- Read `context.file_bytes` and `context.scan_id`
+- Encrypt and persist the file
+- Return an opaque quarantine reference string
+- Raise `QuarantineError` on any storage failure
+
+### `QuarantineError`
+
+Raised by `QuarantineService.store()` when storage fails.  The
+`DispositionEngine` catches this and falls back to `block`.
+
+---
+
+## Pipeline Integration
+
+```python
+from fileguard.core.disposition import DispositionEngine
+from fileguard.core.scan_context import ScanContext
+
+# Construct once (stateless; safe to share across coroutines)
+engine = DispositionEngine(quarantine_service=my_quarantine_service)
+
+# Per-scan usage
+ctx = ScanContext(file_bytes=raw_bytes, mime_type="application/pdf")
+# ... run AV scan, PII detection steps ...
+result = await engine.decide(ctx, rules=tenant_config.disposition_rules)
+
+match result.action:
+    case "pass":
+        return {"status": result.status, "action": "pass"}
+    case "block":
+        raise HTTPException(status_code=403, detail="File rejected")
+    case "quarantine":
+        return {"status": "rejected", "quarantine_ref": result.quarantine_ref}
+```
+
+---
+
+## Fail-Secure Guarantees
+
+1. **Exception safety:** The outer `decide()` method wraps `_evaluate()` in a
+   broad `except Exception` catch. Any unexpected exception yields
+   `action="block"` with a reason string describing the exception type and
+   message.
+
+2. **Scan errors:** When `context.errors` is non-empty (set by upstream
+   pipeline steps on AV or PII backend failures), the engine applies
+   `on_error` (default `"block"`) without inspecting findings.
+
+3. **Quarantine fallback:** If no `QuarantineService` is configured, or if
+   `QuarantineService.store()` raises any exception, the quarantine action
+   falls back to `block` automatically.
+
+4. **Invalid rules:** Unrecognised action values in the rules dict are silently
+   ignored; the engine falls through to the next resolution level (top-level
+   rule, then built-in default).
+
+---
+
+## Testing
+
+All disposition outcomes and edge cases are covered by
+`fileguard/tests/test_disposition.py`:
+
+| Test class | Coverage |
+|---|---|
+| `TestCleanPass` | No findings → `pass`/`clean` |
+| `TestAVThreatDisposition` | AV-threat rule resolution, MIME overrides, multi-threat reasons |
+| `TestPIIDisposition` | PII pass-with-flags, block, quarantine, MIME overrides, AV priority |
+| `TestScanErrorDisposition` | Error-triggered block, custom `on_error` rule, error priority |
+| `TestQuarantineFallback` | No service → block; `QuarantineError` → block; unexpected exception → block |
+| `TestFailSecureException` | Exception during evaluation → block, never pass |
+| `TestRuleEdgeCases` | Empty rules, unknown MIME type, invalid action values |
+| `TestResolveAction` | `_resolve_action` helper priority and defaults |
+| `TestDeriveStatus` | `_derive_status` all action/findings combinations |
+| `TestDispositionResult` | Immutability, field defaults |
+| `TestQuarantineServiceInterface` | Abstract interface, `QuarantineError` type |

--- a/fileguard/core/disposition.py
+++ b/fileguard/core/disposition.py
@@ -1,0 +1,543 @@
+"""DispositionEngine — rule-based file disposition for the FileGuard pipeline.
+
+:class:`DispositionEngine` evaluates AV and PII findings accumulated in a
+:class:`~fileguard.core.scan_context.ScanContext` against per-tenant,
+per-file-type disposition rules and produces a final
+:class:`DispositionResult` of ``block``, ``quarantine``, or ``pass``.
+
+**Fail-secure guarantee:** any unhandled exception during rule evaluation
+results in a ``block`` outcome.  A file is *never* silently passed through
+when the engine encounters an error.
+
+**Disposition rule schema** (stored as JSONB in ``tenant_config.disposition_rules``):
+
+.. code-block:: json
+
+    {
+        "on_error":     "block",
+        "on_av_threat": "block",
+        "on_pii":       "pass",
+        "mime_type_overrides": {
+            "application/pdf": {
+                "on_pii": "quarantine"
+            }
+        }
+    }
+
+All keys are optional.  The built-in defaults apply whenever a key is absent:
+
+* ``on_error``     → ``"block"``   (scan errors are always fail-secure)
+* ``on_av_threat`` → ``"block"``   (AV threats are blocked by default)
+* ``on_pii``       → ``"pass"``    (PII triggers a flag but passes through)
+
+Usage::
+
+    from fileguard.core.disposition import DispositionEngine
+    from fileguard.core.scan_context import ScanContext
+
+    engine = DispositionEngine()
+    ctx = ScanContext(file_bytes=b"...", mime_type="application/pdf")
+    # ... run AV and PII pipeline steps ...
+    result = await engine.decide(ctx, rules=tenant.disposition_rules)
+    print(result.action, result.status)
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from fileguard.core.scan_context import ScanContext
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Action and status types
+# ---------------------------------------------------------------------------
+
+Action = Literal["pass", "quarantine", "block"]
+Status = Literal["clean", "flagged", "rejected"]
+
+# Severity ordering for PII-based rule evaluation (higher index = higher severity)
+_SEVERITY_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+# Default actions when no rule is specified
+_DEFAULT_ON_ERROR = "block"
+_DEFAULT_ON_AV_THREAT = "block"
+_DEFAULT_ON_PII = "pass"
+
+
+# ---------------------------------------------------------------------------
+# QuarantineService interface
+# ---------------------------------------------------------------------------
+
+
+class QuarantineService(ABC):
+    """Abstract interface for the quarantine storage backend.
+
+    The :class:`DispositionEngine` depends on this interface to store
+    quarantined files.  Concrete implementations (e.g. S3-backed AES-256
+    encrypted store) are injected at construction time.
+
+    This interface allows the DispositionEngine to be tested independently
+    of storage infrastructure by substituting a mock.
+    """
+
+    @abstractmethod
+    async def store(self, context: ScanContext) -> str:
+        """Encrypt and store the file bytes from *context* in quarantine.
+
+        Args:
+            context: The shared :class:`~fileguard.core.scan_context.ScanContext`
+                for the current scan.  The implementation reads
+                ``context.file_bytes`` and associates the stored object with
+                ``context.scan_id``.
+
+        Returns:
+            An opaque quarantine reference string (e.g. an S3 object key or
+            a URN) that can be used to retrieve or audit the quarantined file.
+
+        Raises:
+            :class:`QuarantineError`: If the file could not be stored.  The
+                caller (DispositionEngine) treats this as a hard failure and
+                falls back to a ``block`` outcome.
+        """
+
+
+class QuarantineError(Exception):
+    """Raised when the quarantine store fails to store a file.
+
+    Callers must treat this as a hard failure and apply fail-secure block
+    disposition rather than silently passing the file through.
+    """
+
+
+# ---------------------------------------------------------------------------
+# DispositionResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DispositionResult:
+    """Immutable result of a disposition evaluation.
+
+    Attributes:
+        action: The resolved action taken on the file:
+
+            - ``"pass"``       – file is allowed through.
+            - ``"quarantine"`` – file was written to quarantine storage.
+            - ``"block"``      – file is rejected outright.
+
+        status: Overall verdict derived from the action and findings:
+
+            - ``"clean"``    – action is ``"pass"`` and no findings were
+              present.
+            - ``"flagged"``  – action is ``"pass"`` but findings were recorded
+              (pass-with-flags).
+            - ``"rejected"`` – action is ``"block"`` or ``"quarantine"``.
+
+        quarantine_ref: Opaque reference returned by the
+            :class:`QuarantineService` when the action is ``"quarantine"``.
+            ``None`` for all other actions.
+        reasons: Human-readable strings explaining why each rule fired.  Useful
+            for audit logs and SIEM event payloads.
+    """
+
+    action: Action
+    status: Status
+    quarantine_ref: str | None = None
+    reasons: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Internal rule resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_action(
+    rules: dict[str, Any],
+    mime_type: str,
+    rule_key: str,
+    default: Action,
+) -> Action:
+    """Return the action for *rule_key*, applying MIME-type overrides.
+
+    Resolution order:
+    1. ``rules["mime_type_overrides"][mime_type][rule_key]``
+    2. ``rules[rule_key]``
+    3. *default*
+
+    Any value that is not a valid :data:`Action` literal is ignored and the
+    next level in the resolution chain is tried, so malformed rule entries
+    do not crash the engine (fail-secure: unknown values fall through to the
+    default).
+
+    Args:
+        rules: Disposition rules dict from ``TenantConfig.disposition_rules``.
+        mime_type: MIME type of the file being scanned (e.g.
+            ``"application/pdf"``).
+        rule_key: The rule key to look up (``"on_error"``,
+            ``"on_av_threat"``, or ``"on_pii"``).
+        default: Fallback action when no valid rule is found.
+
+    Returns:
+        The resolved :data:`Action` value.
+    """
+    valid_actions: frozenset[str] = frozenset({"pass", "quarantine", "block"})
+
+    # Check MIME-type-specific override first
+    overrides: dict[str, Any] = rules.get("mime_type_overrides", {}) or {}
+    mime_rules: dict[str, Any] = overrides.get(mime_type, {}) or {}
+    mime_value = mime_rules.get(rule_key)
+    if mime_value in valid_actions:
+        return mime_value  # type: ignore[return-value]
+
+    # Fall back to top-level rule
+    top_value = rules.get(rule_key)
+    if top_value in valid_actions:
+        return top_value  # type: ignore[return-value]
+
+    return default
+
+
+def _derive_status(action: Action, has_findings: bool) -> Status:
+    """Derive the overall scan status from the resolved *action* and findings.
+
+    Args:
+        action: The resolved disposition action.
+        has_findings: ``True`` if the scan context has any findings (AV or PII).
+
+    Returns:
+        ``"clean"`` when the file passes with no findings.
+        ``"flagged"`` when the file passes but findings were recorded.
+        ``"rejected"`` when the file is blocked or quarantined.
+    """
+    if action in ("block", "quarantine"):
+        return "rejected"
+    return "flagged" if has_findings else "clean"
+
+
+# ---------------------------------------------------------------------------
+# DispositionEngine
+# ---------------------------------------------------------------------------
+
+
+class DispositionEngine:
+    """Evaluates scan findings against disposition rules and resolves an action.
+
+    The engine is stateless after construction.  The same instance can be
+    reused concurrently from multiple asyncio tasks.
+
+    Args:
+        quarantine_service: Optional :class:`QuarantineService` implementation
+            used to store files when the resolved action is ``"quarantine"``.
+            When ``None``, a quarantine decision falls back to ``"block"``
+            and a warning is logged.
+
+    Example — inline usage::
+
+        engine = DispositionEngine(quarantine_service=my_qs)
+        result = await engine.decide(ctx, rules=tenant_config.disposition_rules)
+        if result.action == "block":
+            raise HTTPException(status_code=403, detail="File rejected")
+
+    Example — no quarantine service::
+
+        engine = DispositionEngine()          # quarantine falls back to block
+        result = await engine.decide(ctx)     # uses built-in defaults
+    """
+
+    def __init__(
+        self,
+        quarantine_service: QuarantineService | None = None,
+    ) -> None:
+        self._quarantine_service = quarantine_service
+
+    # ------------------------------------------------------------------
+    # Primary pipeline entry point
+    # ------------------------------------------------------------------
+
+    async def decide(
+        self,
+        context: ScanContext,
+        rules: dict[str, Any] | None = None,
+    ) -> DispositionResult:
+        """Evaluate findings in *context* and return a disposition decision.
+
+        This is the primary pipeline integration point.  It reads
+        ``context.findings`` and ``context.errors``, resolves the applicable
+        disposition rules, and returns an immutable :class:`DispositionResult`.
+
+        **Fail-secure:** any unhandled exception during rule evaluation is
+        caught, logged, and results in a ``block`` outcome.  The file is
+        *never* silently passed through on error.
+
+        Args:
+            context: The shared :class:`~fileguard.core.scan_context.ScanContext`
+                for the current scan.  Read-only — this method does not
+                mutate the context.
+            rules: Disposition rules dict (typically from
+                ``TenantConfig.disposition_rules``).  ``None`` or an empty
+                dict applies the built-in fail-secure defaults.
+
+        Returns:
+            An immutable :class:`DispositionResult` describing the resolved
+            action, derived scan status, optional quarantine reference, and
+            the human-readable reasons that drove the decision.
+        """
+        try:
+            return await self._evaluate(context, rules or {})
+        except Exception as exc:
+            logger.error(
+                "DispositionEngine unhandled exception (scan_id=%s): %r — "
+                "applying fail-secure block",
+                context.scan_id,
+                exc,
+                exc_info=True,
+            )
+            return DispositionResult(
+                action="block",
+                status="rejected",
+                quarantine_ref=None,
+                reasons=[
+                    f"fail-secure: unhandled exception during disposition "
+                    f"evaluation: {type(exc).__name__}: {exc}"
+                ],
+            )
+
+    # ------------------------------------------------------------------
+    # Internal evaluation logic
+    # ------------------------------------------------------------------
+
+    async def _evaluate(
+        self,
+        context: ScanContext,
+        rules: dict[str, Any],
+    ) -> DispositionResult:
+        """Core disposition logic (not wrapped in fail-secure catch).
+
+        Separated so that the outer :meth:`decide` can cleanly catch any
+        exception that escapes this method.
+        """
+        reasons: list[str] = []
+        mime_type = context.mime_type or ""
+
+        # ---------------------------------------------------------------
+        # 1. Scan errors → fail-secure block (highest priority)
+        # ---------------------------------------------------------------
+        if context.errors:
+            error_action = _resolve_action(
+                rules, mime_type, "on_error", _DEFAULT_ON_ERROR
+            )
+            for err in context.errors:
+                reasons.append(f"scan error: {err}")
+
+            logger.warning(
+                "DispositionEngine: scan_id=%s errors=%d action=%s",
+                context.scan_id,
+                len(context.errors),
+                error_action,
+            )
+
+            result = await self._apply_action(
+                action=error_action,
+                context=context,
+                reasons=reasons,
+            )
+            logger.info(
+                "DispositionEngine decision: scan_id=%s action=%s status=%s "
+                "reasons=%r",
+                context.scan_id,
+                result.action,
+                result.status,
+                result.reasons,
+            )
+            return result
+
+        # ---------------------------------------------------------------
+        # 2. Classify findings
+        # ---------------------------------------------------------------
+        av_findings = [f for f in context.findings if getattr(f, "type", None) == "av_threat"]
+        pii_findings = [f for f in context.findings if getattr(f, "type", None) == "pii"]
+        has_findings = bool(av_findings or pii_findings)
+
+        # ---------------------------------------------------------------
+        # 3. AV threats → highest-priority action after errors
+        # ---------------------------------------------------------------
+        if av_findings:
+            av_action = _resolve_action(
+                rules, mime_type, "on_av_threat", _DEFAULT_ON_AV_THREAT
+            )
+            for finding in av_findings:
+                cat = getattr(finding, "category", "unknown")
+                match = getattr(finding, "match", "")
+                reasons.append(f"av_threat: category={cat} match={match!r}")
+
+            logger.warning(
+                "DispositionEngine: scan_id=%s av_threats=%d action=%s",
+                context.scan_id,
+                len(av_findings),
+                av_action,
+            )
+
+            result = await self._apply_action(
+                action=av_action,
+                context=context,
+                reasons=reasons,
+            )
+            logger.info(
+                "DispositionEngine decision: scan_id=%s action=%s status=%s "
+                "reasons=%r",
+                context.scan_id,
+                result.action,
+                result.status,
+                result.reasons,
+            )
+            return result
+
+        # ---------------------------------------------------------------
+        # 4. PII findings
+        # ---------------------------------------------------------------
+        if pii_findings:
+            pii_action = _resolve_action(
+                rules, mime_type, "on_pii", _DEFAULT_ON_PII
+            )
+            for finding in pii_findings:
+                cat = getattr(finding, "category", "unknown")
+                sev = getattr(finding, "severity", "unknown")
+                reasons.append(f"pii: category={cat} severity={sev}")
+
+            logger.info(
+                "DispositionEngine: scan_id=%s pii_findings=%d action=%s",
+                context.scan_id,
+                len(pii_findings),
+                pii_action,
+            )
+
+            result = await self._apply_action(
+                action=pii_action,
+                context=context,
+                reasons=reasons,
+            )
+            logger.info(
+                "DispositionEngine decision: scan_id=%s action=%s status=%s "
+                "reasons=%r",
+                context.scan_id,
+                result.action,
+                result.status,
+                result.reasons,
+            )
+            return result
+
+        # ---------------------------------------------------------------
+        # 5. No findings — clean pass
+        # ---------------------------------------------------------------
+        logger.info(
+            "DispositionEngine decision: scan_id=%s action=pass status=clean",
+            context.scan_id,
+        )
+        return DispositionResult(
+            action="pass",
+            status="clean",
+            quarantine_ref=None,
+            reasons=[],
+        )
+
+    async def _apply_action(
+        self,
+        action: Action,
+        context: ScanContext,
+        reasons: list[str],
+    ) -> DispositionResult:
+        """Execute the resolved *action* and return a :class:`DispositionResult`.
+
+        For ``"quarantine"`` actions this method delegates to the
+        :class:`QuarantineService`.  If no quarantine service is configured,
+        or if the service raises :class:`QuarantineError`, the action falls
+        back to ``"block"`` (fail-secure).
+
+        Args:
+            action: The resolved disposition action.
+            context: The current scan context (used by quarantine service).
+            reasons: List of human-readable reason strings accumulated by the
+                caller.
+
+        Returns:
+            A :class:`DispositionResult` with the final action, derived
+            status, and quarantine reference (if applicable).
+        """
+        has_findings = bool(context.findings)
+
+        if action == "quarantine":
+            quarantine_ref = await self._store_quarantine(context)
+            if quarantine_ref is None:
+                # Quarantine failed — fall back to block (fail-secure)
+                return DispositionResult(
+                    action="block",
+                    status="rejected",
+                    quarantine_ref=None,
+                    reasons=reasons + [
+                        "quarantine store unavailable — falling back to block"
+                    ],
+                )
+            return DispositionResult(
+                action="quarantine",
+                status="rejected",
+                quarantine_ref=quarantine_ref,
+                reasons=reasons,
+            )
+
+        # "block" or "pass"
+        status = _derive_status(action, has_findings)
+        return DispositionResult(
+            action=action,
+            status=status,
+            quarantine_ref=None,
+            reasons=reasons,
+        )
+
+    async def _store_quarantine(self, context: ScanContext) -> str | None:
+        """Attempt to quarantine the file; return the ref or ``None`` on failure.
+
+        Args:
+            context: The current scan context passed to the quarantine service.
+
+        Returns:
+            The quarantine reference string, or ``None`` if storage failed or
+            no :class:`QuarantineService` is configured.
+        """
+        if self._quarantine_service is None:
+            logger.warning(
+                "DispositionEngine: quarantine action requested but no "
+                "QuarantineService configured (scan_id=%s) — falling back to block",
+                context.scan_id,
+            )
+            return None
+
+        try:
+            ref = await self._quarantine_service.store(context)
+            logger.info(
+                "DispositionEngine: file quarantined scan_id=%s ref=%r",
+                context.scan_id,
+                ref,
+            )
+            return ref
+        except QuarantineError as exc:
+            logger.error(
+                "DispositionEngine: quarantine store failed (scan_id=%s): %r "
+                "— falling back to block",
+                context.scan_id,
+                exc,
+            )
+            return None
+        except Exception as exc:
+            logger.error(
+                "DispositionEngine: unexpected quarantine error (scan_id=%s): %r "
+                "— falling back to block",
+                context.scan_id,
+                exc,
+                exc_info=True,
+            )
+            return None

--- a/fileguard/tests/test_disposition.py
+++ b/fileguard/tests/test_disposition.py
@@ -1,0 +1,664 @@
+"""Unit tests for DispositionEngine rule evaluation and fail-secure behaviour.
+
+Coverage targets
+----------------
+* **Pass (clean)** — no findings, no errors → action="pass", status="clean".
+* **Pass-with-flags** — PII findings with on_pii="pass" rule → action="pass",
+  status="flagged".
+* **Block on AV threat** — AV threat findings → action="block",
+  status="rejected".
+* **Quarantine on PII** — PII findings with on_pii="quarantine" rule and
+  configured QuarantineService → action="quarantine", quarantine_ref set.
+* **Block (quarantine fallback)** — quarantine action but no service
+  configured → action="block".
+* **Block on scan error** — context.errors populated → action="block",
+  on_error rule respected.
+* **Fail-secure exception path** — exception raised during evaluation →
+  action="block", status="rejected", reason explains the exception.
+* **Rule resolution** — MIME-type overrides take precedence over top-level
+  rules; invalid rule values are ignored (default applied).
+* **QuarantineService failure** — store() raises QuarantineError → falls
+  back to block.
+* **_resolve_action helper** — priority order and default fallback.
+* **_derive_status helper** — all action/findings combinations.
+* **DispositionResult is immutable** (frozen dataclass).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import FrozenInstanceError
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure required env vars are present before importing fileguard modules
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-at-least-32-chars!!")
+
+from fileguard.core.disposition import (
+    DispositionEngine,
+    DispositionResult,
+    QuarantineError,
+    QuarantineService,
+    _DEFAULT_ON_AV_THREAT,
+    _DEFAULT_ON_ERROR,
+    _DEFAULT_ON_PII,
+    _derive_status,
+    _resolve_action,
+)
+from fileguard.core.scan_context import ScanContext
+
+
+# ---------------------------------------------------------------------------
+# Helpers / factories
+# ---------------------------------------------------------------------------
+
+
+def make_context(
+    mime_type: str = "application/octet-stream",
+    findings: list[Any] | None = None,
+    errors: list[str] | None = None,
+) -> ScanContext:
+    """Return a ScanContext with the given attributes pre-populated."""
+    ctx = ScanContext(file_bytes=b"test-file-bytes", mime_type=mime_type)
+    if findings is not None:
+        ctx.findings.extend(findings)
+    if errors is not None:
+        ctx.errors.extend(errors)
+    return ctx
+
+
+def av_finding(category: str = "Win.Test", match: str = "EICAR") -> MagicMock:
+    """Return a mock AV-threat finding."""
+    f = MagicMock()
+    f.type = "av_threat"
+    f.category = category
+    f.match = match
+    f.severity = "high"
+    return f
+
+
+def pii_finding(
+    category: str = "NI_NUMBER", severity: str = "high"
+) -> MagicMock:
+    """Return a mock PII finding."""
+    f = MagicMock()
+    f.type = "pii"
+    f.category = category
+    f.severity = severity
+    return f
+
+
+class FakeQuarantineService(QuarantineService):
+    """Test double for QuarantineService that records calls."""
+
+    def __init__(self, ref: str = "quarantine://test-ref-001") -> None:
+        self._ref = ref
+        self.calls: list[ScanContext] = []
+
+    async def store(self, context: ScanContext) -> str:
+        self.calls.append(context)
+        return self._ref
+
+
+class FailingQuarantineService(QuarantineService):
+    """Test double that always raises QuarantineError."""
+
+    async def store(self, context: ScanContext) -> str:
+        raise QuarantineError("quarantine store unavailable")
+
+
+class ExplodingQuarantineService(QuarantineService):
+    """Test double that raises a generic (non-QuarantineError) exception."""
+
+    async def store(self, context: ScanContext) -> str:
+        raise RuntimeError("unexpected storage backend failure")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_action helper
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAction:
+    def test_returns_default_when_rules_empty(self):
+        result = _resolve_action({}, "application/pdf", "on_pii", "pass")
+        assert result == "pass"
+
+    def test_returns_top_level_rule(self):
+        rules = {"on_pii": "block"}
+        result = _resolve_action(rules, "text/plain", "on_pii", "pass")
+        assert result == "block"
+
+    def test_mime_type_override_takes_priority(self):
+        rules = {
+            "on_pii": "pass",
+            "mime_type_overrides": {
+                "application/pdf": {"on_pii": "quarantine"},
+            },
+        }
+        result = _resolve_action(rules, "application/pdf", "on_pii", "pass")
+        assert result == "quarantine"
+
+    def test_top_level_rule_used_when_no_mime_override(self):
+        rules = {
+            "on_pii": "block",
+            "mime_type_overrides": {
+                "application/pdf": {"on_av_threat": "quarantine"},
+            },
+        }
+        result = _resolve_action(rules, "application/pdf", "on_pii", "pass")
+        assert result == "block"
+
+    def test_default_used_when_mime_override_has_different_key(self):
+        rules = {
+            "mime_type_overrides": {
+                "application/pdf": {"on_av_threat": "block"},
+            },
+        }
+        result = _resolve_action(rules, "application/pdf", "on_pii", "pass")
+        assert result == "pass"
+
+    def test_invalid_value_falls_through_to_default(self):
+        rules = {"on_pii": "invalid-action"}
+        result = _resolve_action(rules, "text/plain", "on_pii", "quarantine")
+        assert result == "quarantine"
+
+    def test_mime_override_invalid_value_falls_through_to_top_level(self):
+        rules = {
+            "on_pii": "block",
+            "mime_type_overrides": {"text/plain": {"on_pii": "bad-value"}},
+        }
+        result = _resolve_action(rules, "text/plain", "on_pii", "pass")
+        assert result == "block"
+
+    def test_none_mime_type_overrides_are_ignored(self):
+        # Handles None values in JSONB gracefully
+        rules = {"on_pii": "quarantine", "mime_type_overrides": None}
+        result = _resolve_action(rules, "application/pdf", "on_pii", "pass")
+        assert result == "quarantine"
+
+    def test_all_three_actions_are_valid(self):
+        for action in ("pass", "quarantine", "block"):
+            rules = {"on_pii": action}
+            assert _resolve_action(rules, "text/plain", "on_pii", "pass") == action
+
+
+# ---------------------------------------------------------------------------
+# _derive_status helper
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveStatus:
+    def test_clean_when_pass_and_no_findings(self):
+        assert _derive_status("pass", False) == "clean"
+
+    def test_flagged_when_pass_and_has_findings(self):
+        assert _derive_status("pass", True) == "flagged"
+
+    def test_rejected_when_block(self):
+        assert _derive_status("block", False) == "rejected"
+        assert _derive_status("block", True) == "rejected"
+
+    def test_rejected_when_quarantine(self):
+        assert _derive_status("quarantine", False) == "rejected"
+        assert _derive_status("quarantine", True) == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# DispositionResult — structure and immutability
+# ---------------------------------------------------------------------------
+
+
+class TestDispositionResult:
+    def test_result_is_immutable(self):
+        result = DispositionResult(action="pass", status="clean")
+        with pytest.raises((FrozenInstanceError, AttributeError, TypeError)):
+            result.action = "block"  # type: ignore[misc]
+
+    def test_quarantine_ref_defaults_to_none(self):
+        result = DispositionResult(action="pass", status="clean")
+        assert result.quarantine_ref is None
+
+    def test_reasons_defaults_to_empty_list(self):
+        result = DispositionResult(action="block", status="rejected")
+        assert result.reasons == []
+
+    def test_all_fields_populated(self):
+        result = DispositionResult(
+            action="quarantine",
+            status="rejected",
+            quarantine_ref="q://ref-123",
+            reasons=["av_threat: category=Win.Test"],
+        )
+        assert result.action == "quarantine"
+        assert result.status == "rejected"
+        assert result.quarantine_ref == "q://ref-123"
+        assert len(result.reasons) == 1
+
+
+# ---------------------------------------------------------------------------
+# DispositionEngine.decide — clean / no-findings path
+# ---------------------------------------------------------------------------
+
+
+class TestCleanPass:
+    """Acceptance criterion: pass action when no findings and no errors."""
+
+    @pytest.mark.asyncio
+    async def test_no_findings_returns_pass_clean(self):
+        engine = DispositionEngine()
+        ctx = make_context()
+        result = await engine.decide(ctx)
+        assert result.action == "pass"
+        assert result.status == "clean"
+        assert result.quarantine_ref is None
+        assert result.reasons == []
+
+    @pytest.mark.asyncio
+    async def test_no_findings_with_rules_still_passes(self):
+        engine = DispositionEngine()
+        ctx = make_context()
+        rules = {"on_av_threat": "block", "on_pii": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "pass"
+        assert result.status == "clean"
+
+    @pytest.mark.asyncio
+    async def test_none_rules_treated_as_empty(self):
+        engine = DispositionEngine()
+        ctx = make_context()
+        result = await engine.decide(ctx, rules=None)
+        assert result.action == "pass"
+        assert result.status == "clean"
+
+
+# ---------------------------------------------------------------------------
+# DispositionEngine.decide — AV threat path
+# ---------------------------------------------------------------------------
+
+
+class TestAVThreatDisposition:
+    """Acceptance criterion: block action resolved for AV threats."""
+
+    @pytest.mark.asyncio
+    async def test_av_threat_default_block(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[av_finding()])
+        result = await engine.decide(ctx)
+        assert result.action == "block"
+        assert result.status == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_av_threat_reason_recorded(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[av_finding(category="Trojan.PDF", match="evil")])
+        result = await engine.decide(ctx)
+        assert any("av_threat" in r for r in result.reasons)
+        assert any("Trojan.PDF" in r for r in result.reasons)
+
+    @pytest.mark.asyncio
+    async def test_av_threat_rule_quarantine(self):
+        qs = FakeQuarantineService()
+        engine = DispositionEngine(quarantine_service=qs)
+        ctx = make_context(findings=[av_finding()])
+        rules = {"on_av_threat": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "quarantine"
+        assert result.status == "rejected"
+        assert result.quarantine_ref == qs._ref
+        assert len(qs.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_av_threat_rule_pass_allowed(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[av_finding()])
+        rules = {"on_av_threat": "pass"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "pass"
+        assert result.status == "flagged"  # findings present → flagged
+
+    @pytest.mark.asyncio
+    async def test_av_threat_mime_override(self):
+        engine = DispositionEngine()
+        ctx = make_context(mime_type="image/png", findings=[av_finding()])
+        rules = {
+            "on_av_threat": "block",
+            "mime_type_overrides": {"image/png": {"on_av_threat": "pass"}},
+        }
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "pass"
+        assert result.status == "flagged"
+
+    @pytest.mark.asyncio
+    async def test_multiple_av_threats_all_recorded_in_reasons(self):
+        engine = DispositionEngine()
+        findings = [
+            av_finding(category="Trojan.Generic", match="evil1"),
+            av_finding(category="Win.Test", match="evil2"),
+        ]
+        ctx = make_context(findings=findings)
+        result = await engine.decide(ctx)
+        assert result.action == "block"
+        # Both findings should appear in reasons
+        assert sum(1 for r in result.reasons if "av_threat" in r) == 2
+
+
+# ---------------------------------------------------------------------------
+# DispositionEngine.decide — PII path
+# ---------------------------------------------------------------------------
+
+
+class TestPIIDisposition:
+    """Acceptance criterion: pass-with-flags and quarantine for PII findings."""
+
+    @pytest.mark.asyncio
+    async def test_pii_default_pass_with_flags(self):
+        """Default on_pii is 'pass', so PII findings → pass-with-flags."""
+        engine = DispositionEngine()
+        ctx = make_context(findings=[pii_finding()])
+        result = await engine.decide(ctx)
+        assert result.action == "pass"
+        assert result.status == "flagged"
+
+    @pytest.mark.asyncio
+    async def test_pii_reason_recorded(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[pii_finding(category="NHS_NUMBER", severity="high")])
+        result = await engine.decide(ctx)
+        assert any("pii" in r for r in result.reasons)
+        assert any("NHS_NUMBER" in r for r in result.reasons)
+
+    @pytest.mark.asyncio
+    async def test_pii_rule_block(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[pii_finding()])
+        rules = {"on_pii": "block"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "block"
+        assert result.status == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_pii_rule_quarantine_with_service(self):
+        qs = FakeQuarantineService(ref="s3://quarantine/abc123")
+        engine = DispositionEngine(quarantine_service=qs)
+        ctx = make_context(
+            mime_type="application/pdf",
+            findings=[pii_finding()],
+        )
+        rules = {"on_pii": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "quarantine"
+        assert result.status == "rejected"
+        assert result.quarantine_ref == "s3://quarantine/abc123"
+        assert qs.calls[0] is ctx
+
+    @pytest.mark.asyncio
+    async def test_pii_mime_override_quarantine(self):
+        qs = FakeQuarantineService()
+        engine = DispositionEngine(quarantine_service=qs)
+        ctx = make_context(mime_type="application/pdf", findings=[pii_finding()])
+        rules = {
+            "on_pii": "pass",
+            "mime_type_overrides": {"application/pdf": {"on_pii": "quarantine"}},
+        }
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "quarantine"
+        assert result.quarantine_ref is not None
+
+    @pytest.mark.asyncio
+    async def test_multiple_pii_findings_all_in_reasons(self):
+        engine = DispositionEngine()
+        findings = [
+            pii_finding(category="NI_NUMBER", severity="high"),
+            pii_finding(category="EMAIL", severity="medium"),
+        ]
+        ctx = make_context(findings=findings)
+        result = await engine.decide(ctx)
+        pii_reasons = [r for r in result.reasons if "pii" in r]
+        assert len(pii_reasons) == 2
+
+    @pytest.mark.asyncio
+    async def test_pii_takes_lower_priority_than_av(self):
+        """When both AV and PII findings exist, AV rule takes effect."""
+        engine = DispositionEngine()
+        ctx = make_context(findings=[av_finding(), pii_finding()])
+        # Default: on_av_threat=block, on_pii=pass
+        result = await engine.decide(ctx)
+        # AV threat is evaluated first and results in block
+        assert result.action == "block"
+        assert result.status == "rejected"
+        assert any("av_threat" in r for r in result.reasons)
+
+
+# ---------------------------------------------------------------------------
+# DispositionEngine.decide — scan errors path
+# ---------------------------------------------------------------------------
+
+
+class TestScanErrorDisposition:
+    """Acceptance criterion: errors in context trigger fail-secure block."""
+
+    @pytest.mark.asyncio
+    async def test_context_errors_trigger_block(self):
+        engine = DispositionEngine()
+        ctx = make_context(errors=["clamav: connection refused"])
+        result = await engine.decide(ctx)
+        assert result.action == "block"
+        assert result.status == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_error_reason_recorded(self):
+        engine = DispositionEngine()
+        ctx = make_context(errors=["dlp: timeout after 30s"])
+        result = await engine.decide(ctx)
+        assert any("scan error" in r for r in result.reasons)
+        assert any("dlp: timeout" in r for r in result.reasons)
+
+    @pytest.mark.asyncio
+    async def test_on_error_rule_quarantine(self):
+        qs = FakeQuarantineService()
+        engine = DispositionEngine(quarantine_service=qs)
+        ctx = make_context(errors=["backend error"])
+        rules = {"on_error": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "quarantine"
+        assert result.quarantine_ref == qs._ref
+
+    @pytest.mark.asyncio
+    async def test_errors_take_priority_over_av_findings(self):
+        """Errors are evaluated before findings."""
+        engine = DispositionEngine()
+        ctx = make_context(
+            findings=[av_finding()],
+            errors=["scan engine crash"],
+        )
+        result = await engine.decide(ctx)
+        assert result.action == "block"
+        # Error reason appears
+        assert any("scan error" in r for r in result.reasons)
+
+    @pytest.mark.asyncio
+    async def test_multiple_errors_all_in_reasons(self):
+        engine = DispositionEngine()
+        ctx = make_context(errors=["error 1", "error 2"])
+        result = await engine.decide(ctx)
+        error_reasons = [r for r in result.reasons if "scan error" in r]
+        assert len(error_reasons) == 2
+
+
+# ---------------------------------------------------------------------------
+# Quarantine fallback paths
+# ---------------------------------------------------------------------------
+
+
+class TestQuarantineFallback:
+    """Acceptance criterion: quarantine falls back to block on failure."""
+
+    @pytest.mark.asyncio
+    async def test_no_service_configured_falls_back_to_block(self):
+        engine = DispositionEngine(quarantine_service=None)
+        ctx = make_context(findings=[pii_finding()])
+        rules = {"on_pii": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "block"
+        assert result.status == "rejected"
+        assert result.quarantine_ref is None
+        assert any("quarantine" in r.lower() for r in result.reasons)
+
+    @pytest.mark.asyncio
+    async def test_quarantine_error_falls_back_to_block(self):
+        engine = DispositionEngine(quarantine_service=FailingQuarantineService())
+        ctx = make_context(findings=[pii_finding()])
+        rules = {"on_pii": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "block"
+        assert result.status == "rejected"
+        assert result.quarantine_ref is None
+
+    @pytest.mark.asyncio
+    async def test_unexpected_quarantine_exception_falls_back_to_block(self):
+        engine = DispositionEngine(quarantine_service=ExplodingQuarantineService())
+        ctx = make_context(findings=[pii_finding()])
+        rules = {"on_pii": "quarantine"}
+        result = await engine.decide(ctx, rules=rules)
+        assert result.action == "block"
+        assert result.status == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Fail-secure exception path (outer catch)
+# ---------------------------------------------------------------------------
+
+
+class TestFailSecureException:
+    """Acceptance criterion: unhandled exception → block (never silent pass)."""
+
+    @pytest.mark.asyncio
+    async def test_exception_in_evaluate_returns_block(self):
+        """Patch the internal _evaluate method to raise unexpectedly."""
+        engine = DispositionEngine()
+        ctx = make_context()
+
+        with patch.object(
+            engine,
+            "_evaluate",
+            side_effect=RuntimeError("simulated crash"),
+        ):
+            result = await engine.decide(ctx)
+
+        assert result.action == "block"
+        assert result.status == "rejected"
+        assert result.quarantine_ref is None
+        assert len(result.reasons) == 1
+        assert "fail-secure" in result.reasons[0]
+        assert "RuntimeError" in result.reasons[0]
+
+    @pytest.mark.asyncio
+    async def test_exception_reason_includes_message(self):
+        engine = DispositionEngine()
+        ctx = make_context()
+
+        with patch.object(
+            engine,
+            "_evaluate",
+            side_effect=ValueError("unexpected schema version"),
+        ):
+            result = await engine.decide(ctx)
+
+        assert "unexpected schema version" in result.reasons[0]
+
+    @pytest.mark.asyncio
+    async def test_exception_never_passes_file_through(self):
+        """Regardless of findings, an exception must NEVER result in pass."""
+        engine = DispositionEngine()
+        ctx = make_context()  # no findings, no errors
+
+        with patch.object(engine, "_evaluate", side_effect=Exception("boom")):
+            result = await engine.decide(ctx)
+
+        # File must NOT pass through silently
+        assert result.action != "pass"
+        assert result.status == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Rule edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRuleEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_rules_dict_uses_defaults(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[av_finding()])
+        result = await engine.decide(ctx, rules={})
+        # Default on_av_threat is "block"
+        assert result.action == "block"
+
+    @pytest.mark.asyncio
+    async def test_unknown_mime_type_uses_top_level_rule(self):
+        engine = DispositionEngine()
+        ctx = make_context(
+            mime_type="application/x-custom",
+            findings=[pii_finding()],
+        )
+        rules = {
+            "on_pii": "block",
+            "mime_type_overrides": {"application/pdf": {"on_pii": "pass"}},
+        }
+        result = await engine.decide(ctx, rules=rules)
+        # No override for "application/x-custom" → top-level "block"
+        assert result.action == "block"
+
+    @pytest.mark.asyncio
+    async def test_invalid_on_pii_value_uses_default_pass(self):
+        engine = DispositionEngine()
+        ctx = make_context(findings=[pii_finding()])
+        rules = {"on_pii": "totally-invalid-action"}
+        result = await engine.decide(ctx, rules=rules)
+        # Invalid value → default is "pass"
+        assert result.action == "pass"
+        assert result.status == "flagged"
+
+    @pytest.mark.asyncio
+    async def test_findings_mixed_types_av_takes_priority(self):
+        engine = DispositionEngine()
+        ctx = make_context(
+            findings=[pii_finding(), av_finding()],  # PII listed first, AV second
+        )
+        # Default: on_av_threat=block, on_pii=pass
+        result = await engine.decide(ctx)
+        assert result.action == "block"
+
+
+# ---------------------------------------------------------------------------
+# QuarantineService interface
+# ---------------------------------------------------------------------------
+
+
+class TestQuarantineServiceInterface:
+    def test_cannot_instantiate_abstract_class(self):
+        with pytest.raises(TypeError):
+            QuarantineService()  # type: ignore[abstract]
+
+    def test_fake_service_implements_interface(self):
+        qs = FakeQuarantineService()
+        assert isinstance(qs, QuarantineService)
+
+    def test_quarantine_error_is_exception(self):
+        err = QuarantineError("store failed")
+        assert isinstance(err, Exception)
+
+    @pytest.mark.asyncio
+    async def test_fake_service_returns_ref(self):
+        qs = FakeQuarantineService(ref="my-ref")
+        ctx = make_context()
+        ref = await qs.store(ctx)
+        assert ref == "my-ref"
+        assert ctx in qs.calls


### PR DESCRIPTION
## Implementation Complete

## Summary

Implements `DispositionEngine` in `fileguard/core/disposition.py` that evaluates AV and PII findings against per-tenant, per-file-type disposition rules to produce a final action of `block`, `quarantine`, or `pass-with-flags`.

### Key design decisions

- **Fail-secure default:** Any unhandled exception during rule evaluation results in `block`; a file is never silently passed through on error
- **Rule resolution priority:** MIME-type overrides → top-level rules → built-in defaults (`on_error=block`, `on_av_threat=block`, `on_pii=pass`)
- **Evaluation priority:** scan errors → AV threats → PII findings → clean pass
- **QuarantineService interface:** Abstract base class for injectable quarantine storage backends; absent or failing service falls back to `block`
- **Stateless engine:** Same instance safe to use concurrently from multiple asyncio tasks

### Components

- `DispositionEngine` — async `decide()` method wraps `_evaluate()` in fail-secure exception handler
- `DispositionResult` — frozen dataclass with `action`, `status`, `quarantine_ref`, and `reasons`
- `QuarantineService` — abstract interface for quarantine storage backends
- `QuarantineError` — signals storage failure so engine can fall back to block
- `_resolve_action()` — helper for MIME-type-aware rule resolution
- `_derive_status()` — derives scan status from action and presence of findings

### Acceptance criteria met

- [x] Block, quarantine, and pass-with-flags actions correctly resolved from tenant and file-type rules
- [x] Quarantine action invokes `QuarantineService` and records the quarantine reference in `DispositionResult.quarantine_ref`
- [x] Any unhandled exception results in a reject/block outcome with no file passing through
- [x] Unit tests cover all three disposition outcomes and the fail-secure exception path

Closes #280

## Tasks Completed

- [x] Analyze the issue requirements
- [x] Implement the core changes
- [x] Add tests for new functionality
- [x] Update documentation if needed


---
**Issue:** #280 (Closes #280)
**Agent:** `backend-engineer`
**Branch:** `feature/280-fileguard-sprint-4-issue-280`