### PR TITLE
feat: implement getCarImageUrl utility function

### DIFF
--- a/src/utils/imageUrl.test.ts
+++ b/src/utils/imageUrl.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { getCarImageUrl } from './imageUrl';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('getCarImageUrl', () => {
+  // -------------------------------------------------------------------------
+  // Basic functionality
+  // -------------------------------------------------------------------------
+
+  it('constructs image URL for Ferrari model', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari 488');
+    expect(result).toBe('/images/ferrari/488.jpg');
+  });
+
+  it('constructs image URL for Lamborghini model', () => {
+    const result = getCarImageUrl('lamborghini', 'Lamborghini Gallardo');
+    expect(result).toBe('/images/lamborghini/gallardo.jpg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case normalization
+  // -------------------------------------------------------------------------
+
+  it('converts uppercase model names to lowercase', () => {
+    const result = getCarImageUrl('ferrari', 'FERRARI F8');
+    expect(result).toBe('/images/ferrari/f8.jpg');
+  });
+
+  it('converts mixed-case brand to lowercase', () => {
+    const result = getCarImageUrl('Ferrari', 'Ferrari 488');
+    expect(result).toBe('/images/ferrari/488.jpg');
+  });
+
+  it('converts mixed-case brand and model to lowercase', () => {
+    const result = getCarImageUrl('Lamborghini', 'Lamborghini HURACÁN');
+    expect(result).toBe('/images/lamborghini/huracan.jpg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Space to hyphen conversion
+  // -------------------------------------------------------------------------
+
+  it('converts spaces to hyphens in model name', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari F8 Tributo');
+    expect(result).toBe('/images/ferrari/f8-tributo.jpg');
+  });
+
+  it('converts multiple consecutive spaces to single hyphen', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari  488  Pista');
+    expect(result).toBe('/images/ferrari/488-pista.jpg');
+  });
+
+  it('handles leading/trailing spaces in model name', () => {
+    const result = getCarImageUrl('ferrari', '  Ferrari 488  ');
+    expect(result).toBe('/images/ferrari/488.jpg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Diacritical mark removal
+  // -------------------------------------------------------------------------
+
+  it('removes diacriticals (é → e)', () => {
+    const result = getCarImageUrl('lamborghini', 'Lamborghini Huracán');
+    expect(result).toBe('/images/lamborghini/huracan.jpg');
+  });
+
+  it('removes diacriticals (ò → o)', () => {
+    const result = getCarImageUrl('lamborghini', 'Lamborghini Murciélago');
+    expect(result).toBe('/images/lamborghini/murcielago.jpg');
+  });
+
+  it('removes multiple diacriticals', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari Élite Édition');
+    expect(result).toBe('/images/ferrari/elite-edition.jpg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Complex combinations
+  // -------------------------------------------------------------------------
+
+  it('handles model name with spaces and diacriticals', () => {
+    const result = getCarImageUrl('lamborghini', 'Lamborghini Murciélago S');
+    expect(result).toBe('/images/lamborghini/murcielago-s.jpg');
+  });
+
+  it('handles full conversion: mixed case + spaces + diacriticals', () => {
+    const result = getCarImageUrl('Lamborghini', 'LAMBORGHINI Murciélago LP 640');
+    expect(result).toBe('/images/lamborghini/murcielago-lp-640.jpg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  it('handles single-word model names', () => {
+    const result = getCarImageUrl('ferrari', 'Testarossa');
+    expect(result).toBe('/images/ferrari/testarossa.jpg');
+  });
+
+  it('handles numeric model names', () => {
+    const result = getCarImageUrl('ferrari', '458 Italia');
+    expect(result).toBe('/images/ferrari/458-italia.jpg');
+  });
+
+  it('handles brand name in model string (redundant but valid)', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari 488');
+    expect(result).toBe('/images/ferrari/488.jpg');
+  });
+
+  it('handles empty-like input (edge case)', () => {
+    const result = getCarImageUrl('ferrari', '   ');
+    // Trimming spaces results in empty string
+    expect(result).toBe('/images/ferrari/.jpg');
+  });
+
+  // -------------------------------------------------------------------------
+  // URL format verification
+  // -------------------------------------------------------------------------
+
+  it('always includes /images/ prefix', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari 488');
+    expect(result).toMatch(/^\/images\//);
+  });
+
+  it('always ends with .jpg extension', () => {
+    const result = getCarImageUrl('lamborghini', 'Lamborghini Gallardo');
+    expect(result).toMatch(/\.jpg$/);
+  });
+
+  it('includes brand in the path', () => {
+    const result = getCarImageUrl('ferrari', 'Ferrari 488');
+    expect(result).toMatch(/\/ferrari\//);
+  });
+
+  // -------------------------------------------------------------------------
+  // Real-world examples
+  // -------------------------------------------------------------------------
+
+  it('handles real Ferrari models (examples)', () => {
+    expect(getCarImageUrl('ferrari', 'Ferrari 488')).toBe(
+      '/images/ferrari/488.jpg'
+    );
+    expect(getCarImageUrl('ferrari', 'Ferrari F8 Tributo')).toBe(
+      '/images/ferrari/f8-tributo.jpg'
+    );
+    expect(getCarImageUrl('ferrari', 'Ferrari 458 Italia')).toBe(
+      '/images/ferrari/458-italia.jpg'
+    );
+  });
+
+  it('handles real Lamborghini models (examples)', () => {
+    expect(getCarImageUrl('lamborghini', 'Lamborghini Gallardo')).toBe(
+      '/images/lamborghini/gallardo.jpg'
+    );
+    expect(getCarImageUrl('lamborghini', 'Lamborghini Huracán')).toBe(
+      '/images/lamborghini/huracan.jpg'
+    );
+    expect(getCarImageUrl('lamborghini', 'Lamborghini Murciélago')).toBe(
+      '/images/lamborghini/murcielago.jpg'
+    );
+  });
+});

--- a/src/utils/imageUrl.ts
+++ b/src/utils/imageUrl.ts
@@ -1,0 +1,38 @@
+/**
+ * Generates a URL path for a car image.
+ *
+ * Removes the brand prefix from the model name, then converts to a kebab-case
+ * filename (spaces → hyphens, lowercase). Constructs a static image URL at
+ * `/images/{brand}/{model-name}.jpg`.
+ *
+ * @param brand - The car brand (e.g., "ferrari", "lamborghini")
+ * @param modelName - The full model name (e.g., "Ferrari 488", "Lamborghini Huracán")
+ * @returns A URL path for the car image (e.g., "/images/ferrari/488.jpg")
+ *
+ * @example
+ * getCarImageUrl("ferrari", "Ferrari 488")
+ * // Returns: "/images/ferrari/488.jpg"
+ *
+ * @example
+ * getCarImageUrl("lamborghini", "Lamborghini Huracán")
+ * // Returns: "/images/lamborghini/huracan.jpg"
+ */
+export function getCarImageUrl(brand: string, modelName: string): string {
+  // Trim and normalize to lowercase, removing diacritics (é → e, etc.)
+  const normalized = modelName
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+  // Remove brand prefix (e.g., "ferrari " from "ferrari 488")
+  const brandPrefix = brand.toLowerCase();
+  let modelPart = normalized.startsWith(brandPrefix)
+    ? normalized.slice(brandPrefix.length).trim()
+    : normalized;
+
+  // Replace spaces with hyphens
+  const kebabCase = modelPart.replace(/\s+/g, '-');
+
+  return `/images/${brand.toLowerCase()}/${kebabCase}.jpg`;
+}


### PR DESCRIPTION
## Implementation Complete

## Summary

Implemented the `getCarImageUrl` utility function for converting car brand and model names to static image file paths.

## Changes

- **src/utils/imageUrl.ts**: New utility function that:
  - Removes brand prefix from model names (e.g., "Ferrari 488" → "488")
  - Normalizes to lowercase
  - Removes diacritical marks (é → e, ó → o, etc.)
  - Converts spaces to hyphens for kebab-case filenames
  - Returns formatted URL path `/images/{brand}/{model-name}.jpg`

- **src/utils/imageUrl.test.ts**: Comprehensive test suite with 22 test cases covering:
  - Basic functionality with Ferrari and Lamborghini models
  - Case normalization (uppercase/mixed-case handling)
  - Space-to-hyphen conversion
  - Diacritical mark removal
  - Complex combinations of transformations
  - Edge cases and real-world examples
  - URL format validation

## Test Results

✅ All 22 tests passing  
✅ Full test suite runs without breaking existing tests

## Example Usage

```typescript
import { getCarImageUrl } from '../utils/imageUrl';

// Basic usage
getCarImageUrl('ferrari', 'Ferrari 488');
// Returns: "/images/ferrari/488.jpg"

// Handles diacriticals
getCarImageUrl('lamborghini', 'Lamborghini Huracán');
// Returns: "/images/lamborghini/huracan.jpg"

// Handles complex model names
getCarImageUrl('ferrari', 'Ferrari F8 Tributo');
// Returns: "/images/ferrari/f8-tributo.jpg"
```

## Integration

The function is ready to be used by:
- CarCard component for constructing image src attributes
- E2E tests for image availability verification
- Any component that needs to generate car image URLs from model data

Closes #341

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

## Tasks Completed

- [x] Analyze the issue requirements
- [x] Implement the core changes
- [x] Add tests for new functionality
- [x] Update documentation if needed


---
**Issue:** #341 (Closes #341)
**Agent:** `frontend-engineer`
**Branch:** `feature/341-find-images-for-all-the-cars-sprint-2-issue-341`