### PR TITLE
Chesterfield Foodbank: Top 30 UK Funding Opportunities

### DIFF
--- a/funding.md
+++ b/funding.md
@@ -1,0 +1,381 @@
+# Chesterfield Foodbank – Funding Opportunities
+
+> **Focus:** Core operating costs (staffing, rent, utilities, transport, admin)
+> **Network:** Trussell Trust affiliated
+> **Location:** Chesterfield, Derbyshire (East Midlands)
+
+Prioritised by estimated likelihood of success for **core costs**. Trussell Trust affiliation is a strong credibility signal — reference it everywhere.
+
+---
+
+## Priority Tier 1 — High Likelihood ✅
+
+These funders explicitly support core costs and/or have a clear track record with foodbanks and poverty-relief organisations.
+
+---
+
+### 1. 🏆 National Lottery Community Fund – Awards for All
+- **Website:** https://www.tnlcommunityfund.org.uk/funding/programmes/national-lottery-awards-for-all-england
+- **Amount:** Up to £10,000
+- **What they fund:** Core costs explicitly allowed — wages, rent, utilities, running costs
+- **Deadline:** Rolling (open all year)
+- **Requirements:** Registered charity or constituted group, bank account, simple online application (~4 pages)
+- **Chance of success:** ⭐⭐⭐⭐⭐ Very high — this is the most accessible grant in the UK. Foodbanks are a priority sector.
+- **Notes:** Apply immediately if not already done. Fastest route to core funding.
+
+---
+
+### 2. 🏆 National Lottery Community Fund – Reaching Communities
+- **Website:** https://www.tnlcommunityfund.org.uk/funding/programmes/reaching-communities-england
+- **Amount:** £10,000–£500,000 (multi-year available)
+- **What they fund:** Core costs, salaries, project delivery
+- **Deadline:** Rolling
+- **Requirements:** Registered charity, evidence of community need, theory of change
+- **Chance of success:** ⭐⭐⭐⭐ High — larger ask but strong fit for ongoing operations
+- **Notes:** Can cover 2–5 years of core costs. Worth investing time in a quality application.
+
+---
+
+### 3. 🏆 Iceland Foods Charitable Foundation
+- **Website:** https://www.icelandfoundation.co.uk
+- **Amount:** Up to £5,000
+- **What they fund:** Food poverty specifically — foodbanks, food redistribution, community pantries. Core costs supported.
+- **Deadline:** Rolling (trustees meet quarterly)
+- **Requirements:** Registered charity, food-related work, short application
+- **Chance of success:** ⭐⭐⭐⭐⭐ Extremely high for foodbanks — this is their primary focus
+- **Notes:** One of the best-aligned funders for a foodbank. Apply ASAP.
+
+---
+
+### 4. 🏆 Derbyshire Community Foundation
+- **Website:** https://www.derbyshirecommunityfoundation.org.uk
+- **Amount:** £500–£5,000 (small grants); larger grants available
+- **What they fund:** Local community organisations in Derbyshire — food poverty, core costs, community resilience
+- **Deadline:** Multiple rounds per year — check website
+- **Requirements:** Based/operating in Derbyshire, registered charity or constituted group
+- **Chance of success:** ⭐⭐⭐⭐⭐ Very high — you're in their exact geography and sector
+- **Notes:** Multiple programmes; also manages several donor-advised funds specifically for East Midlands. Build a relationship with them.
+
+---
+
+### 5. 🏆 The Tudor Trust
+- **Website:** https://www.tudortrust.org.uk
+- **Amount:** £5,000–£50,000
+- **What they fund:** Core costs **explicitly** — one of the few major trusts that actively prefers to fund core costs over projects
+- **Deadline:** Rolling (apply any time)
+- **Requirements:** Registered charity, income under ~£1.5m preferred, clear social need
+- **Chance of success:** ⭐⭐⭐⭐ High — food poverty + core costs is a strong fit. Takes time to assess (6–9 months)
+- **Notes:** Write honestly about what you need the money for. They dislike jargon. Strong narrative about community need wins here.
+
+---
+
+### 6. 🏆 The Henry Smith Charity
+- **Website:** https://www.henrysmithcharity.org.uk
+- **Amount:** £10,000–£100,000 (multi-year)
+- **What they fund:** Welfare of people in need — poverty, food insecurity. Core costs and salaries funded.
+- **Deadline:** Rolling (trustees meet 4x/year)
+- **Requirements:** Registered charity, audited accounts, operating for 3+ years preferred
+- **Chance of success:** ⭐⭐⭐⭐ High — excellent fit for a Trussell Trust foodbank. Competitive but worth it.
+- **Notes:** Can provide multi-year funding. A strong application could secure 3 years of staffing costs.
+
+---
+
+### 7. 🏆 Coalfields Regeneration Trust
+- **Website:** https://www.coalfields-regen.org.uk
+- **Amount:** Up to £10,000 (community grants); larger capital grants available
+- **What they fund:** Core costs, community support, welfare in former mining communities
+- **Deadline:** Rolling
+- **Requirements:** Operating in a former coalfield area (Chesterfield qualifies — ex-mining area ✅)
+- **Chance of success:** ⭐⭐⭐⭐⭐ Very high — Chesterfield's mining heritage makes this a strong geographic fit
+- **Notes:** Often overlooked. Chesterfield's history as a mining town makes this a priority application.
+
+---
+
+### 8. 🏆 Lloyds Bank Foundation for England and Wales
+- **Website:** https://www.lloydsbankfoundation.org.uk
+- **Amount:** Up to £75,000 over 2 years
+- **What they fund:** Core costs for small charities — explicitly supports organisational sustainability
+- **Deadline:** Check website for programme windows
+- **Requirements:** Income between £25k–£1m, registered charity, working with disadvantaged people
+- **Chance of success:** ⭐⭐⭐⭐ High — they're known for funding the charity itself, not just projects
+- **Notes:** Also offers development support alongside funding. Excellent for building capacity.
+
+---
+
+### 9. 🏆 The Morrisons Foundation
+- **Website:** https://www.morrisonsfoundation.com
+- **Amount:** Up to £25,000
+- **What they fund:** Registered charities tackling food poverty and hunger — core costs allowed
+- **Deadline:** Rolling
+- **Requirements:** Registered charity, strong community impact
+- **Chance of success:** ⭐⭐⭐⭐ High — direct alignment with food poverty mission
+- **Notes:** Morrisons have a store in Chesterfield — local connection may help. Worth mentioning in application.
+
+---
+
+### 10. Chesterfield Borough Council – Community Grants
+- **Website:** https://www.chesterfield.gov.uk/community-and-living/grants-and-funding/
+- **Amount:** Varies (typically £500–£5,000)
+- **What they fund:** Local community organisations, welfare services, core costs
+- **Deadline:** Multiple rounds
+- **Requirements:** Operating in Chesterfield borough
+- **Chance of success:** ⭐⭐⭐⭐ High — local authority priority area; foodbanks typically supported
+- **Notes:** Also explore the Derbyshire County Council community grants separately.
+
+---
+
+## Priority Tier 2 — Good Likelihood 🟡
+
+Strong fit but more competitive or require more complex applications.
+
+---
+
+### 11. The Co-op Foundation
+- **Website:** https://www.co-opfoundation.org.uk
+- **Amount:** Up to £100,000
+- **What they fund:** Food poverty, community resilience, young people — core costs supported in some programmes
+- **Deadline:** Programme-specific — check website
+- **Chance of success:** ⭐⭐⭐ Medium-high — strong thematic fit, competitive pool
+- **Notes:** Co-op often runs specific food poverty programmes. Watch for new rounds.
+
+---
+
+### 12. The Garfield Weston Foundation
+- **Website:** https://garfieldweston.org
+- **Amount:** £10,000–£100,000
+- **What they fund:** Welfare, community, core costs for established charities
+- **Deadline:** Rolling
+- **Requirements:** Registered charity, operating for 3+ years, audited accounts
+- **Chance of success:** ⭐⭐⭐ Medium — large foundation, competitive, but foodbanks are funded
+- **Notes:** Be specific about what core costs you need covered and demonstrate financial resilience plans.
+
+---
+
+### 13. The Esmée Fairbairn Foundation
+- **Website:** https://esmeefairbairn.org.uk
+- **Amount:** £20,000–£500,000
+- **What they fund:** Food system, poverty, community — core costs allowed
+- **Deadline:** Rolling (long lead time — 6–12 months)
+- **Requirements:** Registered charity, strategic vision, larger organisations preferred
+- **Chance of success:** ⭐⭐⭐ Medium — excellent fit but competitive and prefers systemic change narrative
+- **Notes:** Worth applying with a strong story about the food poverty crisis in Chesterfield.
+
+---
+
+### 14. The Evan Cornish Foundation
+- **Website:** https://www.evancornishfoundation.org.uk
+- **Amount:** £2,000–£15,000
+- **What they fund:** Yorkshire and Derbyshire organisations — community welfare, poverty relief
+- **Deadline:** Rolling
+- **Requirements:** Operating in Yorkshire or Derbyshire ✅
+- **Chance of success:** ⭐⭐⭐⭐ High for geography — smaller pool of applicants from Derbyshire
+- **Notes:** Relatively under-the-radar — worth applying. Geographic focus reduces competition.
+
+---
+
+### 15. Asda Foundation
+- **Website:** https://www.asdafoundation.org
+- **Amount:** Up to £50,000 (community fund); smaller local grants also available
+- **What they fund:** Community food initiatives, foodbanks, poverty relief
+- **Deadline:** Rolling
+- **Requirements:** Registered charity or community group
+- **Chance of success:** ⭐⭐⭐ Medium — strong thematic alignment; Asda stores in area may help
+- **Notes:** Check if local Asda store runs a separate community chest programme too.
+
+---
+
+### 16. The Barrow Cadbury Trust
+- **Website:** https://www.barrowcadbury.org.uk
+- **Amount:** £10,000–£60,000
+- **What they fund:** Poverty, social exclusion, welfare — core costs funded
+- **Deadline:** Rolling
+- **Requirements:** Registered charity, evidence of need, community-led approach
+- **Chance of success:** ⭐⭐⭐ Medium — Quaker roots, strong poverty ethos, competitive
+- **Notes:** Good fit philosophically. Strong narrative about dignity and community mutual aid will resonate.
+
+---
+
+### 17. The Benefact Trust (formerly Allchurches Trust)
+- **Website:** https://benefacttrust.co.uk
+- **Amount:** £5,000–£50,000
+- **What they fund:** Christian-ethos organisations and community welfare — core costs included
+- **Deadline:** Rolling (trustees meet quarterly)
+- **Requirements:** Charitable status, preference for church-linked or values-aligned orgs
+- **Chance of success:** ⭐⭐⭐⭐ High if church-connected — lower if fully secular
+- **Notes:** If the foodbank has any church partnership (many Trussell Trust foodbanks do), this is a strong application.
+
+---
+
+### 18. The Summerfield Charitable Trust
+- **Website:** https://www.summerfieldtrust.com
+- **Amount:** £1,000–£15,000
+- **What they fund:** West Midlands and surrounding areas — community welfare
+- **Deadline:** Rolling
+- **Requirements:** Operating in the Midlands region (Derbyshire border — worth checking eligibility)
+- **Chance of success:** ⭐⭐⭐ Medium — geographic boundaries may exclude Chesterfield; worth enquiring
+- **Notes:** Contact them first to confirm Chesterfield falls within their area.
+
+---
+
+### 19. Derbyshire County Council – Locality Grants
+- **Website:** https://www.derbyshire.gov.uk/community/grants-and-funding
+- **Amount:** Up to £5,000
+- **What they fund:** Community organisations, voluntary sector core costs
+- **Deadline:** Check with local councillors — often allocated annually
+- **Chance of success:** ⭐⭐⭐⭐ High — county council prioritises food poverty services
+- **Notes:** Also approach individual Chesterfield ward councillors — they often have discretionary funds.
+
+---
+
+### 20. The Rank Foundation
+- **Website:** https://www.rankfoundation.com
+- **Amount:** Up to £30,000
+- **What they fund:** Christian-values organisations, welfare, poverty relief — core costs supported
+- **Deadline:** Rolling
+- **Requirements:** Preference for Christian ethos; registered charity
+- **Chance of success:** ⭐⭐⭐ Medium — strong if church-linked, lower otherwise
+- **Notes:** Similar profile to Benefact Trust. Worth a parallel application if values-aligned.
+
+---
+
+## Priority Tier 3 — Worth Applying 🔵
+
+These are good opportunities but more competitive, project-focused, or require specific criteria.
+
+---
+
+### 21. Tesco Community Grants (Bags of Change)
+- **Website:** https://www.tescocommunityoffers.co.uk/s/grants
+- **Amount:** Up to £1,500 (local), £5,000–£25,000 (larger rounds)
+- **What they fund:** Community food initiatives, poverty, welfare
+- **Deadline:** Quarterly rounds — check website
+- **Chance of success:** ⭐⭐⭐ Medium — very popular scheme, but foodbanks do well
+- **Notes:** Local Tesco store vote-based element — mobilise community supporters to vote!
+
+---
+
+### 22. Sainsbury's Local Community Fund
+- **Website:** https://www.sainsburys.co.uk/gol-ui/groceries/our-responsibility/community
+- **Amount:** Up to £1,000 per store
+- **What they fund:** Local charities and community groups
+- **Deadline:** Rolling via local store managers
+- **Chance of success:** ⭐⭐⭐ Medium — speak directly to store manager
+- **Notes:** Approach each Chesterfield Sainsbury's directly. Also ask about food donations alongside any cash grant.
+
+---
+
+### 23. The Hadley Trust
+- **Website:** https://www.thehadleytrust.org.uk
+- **Amount:** £5,000–£25,000
+- **What they fund:** Social welfare, poverty relief, community organisations
+- **Deadline:** Rolling (trustees meet 3x/year)
+- **Requirements:** Registered charity; preference for organisations not receiving significant statutory funding
+- **Chance of success:** ⭐⭐⭐ Medium — competitive but thematically strong fit
+- **Notes:** Keep application concise and focused on human impact.
+
+---
+
+### 24. BBC Children in Need
+- **Website:** https://www.bbcchildreninneed.co.uk
+- **Amount:** Up to £10,000 (small grants); larger grants available
+- **What they fund:** Children and young people in poverty — if your foodbank serves families with children
+- **Deadline:** Rolling (small grants) / annual (main grants)
+- **Requirements:** Must evidence direct impact on children under 18
+- **Chance of success:** ⭐⭐⭐ Medium — strong if you can demonstrate child poverty impact
+- **Notes:** Gather data on families with children using the foodbank to strengthen this application.
+
+---
+
+### 25. The Paul Hamlyn Foundation
+- **Website:** https://www.phf.org.uk
+- **Amount:** £20,000–£150,000
+- **What they fund:** Arts access, young people, and community — core costs via specific programmes
+- **Deadline:** Programme-specific
+- **Chance of success:** ⭐⭐ Lower — less direct fit; possible via "Ideas and Pioneers" fund if innovative approach
+- **Notes:** Lower priority unless you have a creative/innovative angle on food poverty work.
+
+---
+
+### 26. Power to Change
+- **Website:** https://www.powertochange.org.uk
+- **Amount:** Up to £300,000 (larger programmes)
+- **What they fund:** Community businesses and social enterprises — core costs funded
+- **Deadline:** Programme-specific
+- **Requirements:** Must operate as a community business (community ownership/governance model)
+- **Chance of success:** ⭐⭐ Medium — requires community business model; check if your governance qualifies
+- **Notes:** If structured correctly, this could provide substantial multi-year core funding.
+
+---
+
+### 27. The John Ellerman Foundation
+- **Website:** https://ellerman.org.uk
+- **Amount:** £20,000–£100,000
+- **What they fund:** Welfare, arts, environment — core costs for well-established charities
+- **Deadline:** Rolling
+- **Requirements:** Registered charity, operating for 5+ years, strong track record
+- **Chance of success:** ⭐⭐ Medium — highly competitive, prefers larger or more established orgs
+- **Notes:** Apply once you have 5+ years of impact data to demonstrate.
+
+---
+
+### 28. Santander Foundation / NatWest Community Fund
+- **Website:** https://www.santanderfoundation.org.uk / https://www.natwest.com/community.html
+- **Amount:** Up to £5,000 (community grants)
+- **What they fund:** Financial inclusion, community welfare, poverty relief
+- **Deadline:** Rolling / quarterly rounds
+- **Chance of success:** ⭐⭐⭐ Medium — broad remit, foodbanks eligible
+- **Notes:** If the foodbank banks with either, mention it. Also check if local branch managers have discretionary community budgets.
+
+---
+
+### 29. Comic Relief / Sport Relief – Grants
+- **Website:** https://www.comicrelief.com/funding
+- **Amount:** Varies by programme (£10k–£500k)
+- **What they fund:** Poverty, food insecurity, UK community programmes — core costs in some programmes
+- **Deadline:** Programme-specific — watch for UK poverty funding rounds
+- **Chance of success:** ⭐⭐ Medium — highly competitive; worth monitoring for relevant programmes
+- **Notes:** Not always open; sign up for alerts at comicrelief.com.
+
+---
+
+### 30. The Joseph Rowntree Foundation / Charitable Trust
+- **Website:** https://www.jrf.org.uk / https://www.jrct.org.uk
+- **Amount:** £10,000–£100,000
+- **What they fund:** Poverty, social justice, systemic change — core costs for frontline organisations
+- **Deadline:** Rolling (JRCT) / varies (JRF)
+- **Requirements:** Registered charity; JRF prefers systemic/policy focus; JRCT more accessible for frontline delivery
+- **Chance of success:** ⭐⭐ Medium — apply to **JRCT** (Charitable Trust) rather than JRF for operational work
+- **Notes:** Frame the application around the structural causes of food poverty in Chesterfield for best resonance.
+
+---
+
+## Quick-Win Summary
+
+| Priority | Funder | Max Amount | Apply By |
+|----------|--------|-----------|----------|
+| 🔴 ASAP | National Lottery – Awards for All | £10,000 | Rolling |
+| 🔴 ASAP | Iceland Foods Charitable Foundation | £5,000 | Rolling |
+| 🔴 ASAP | Derbyshire Community Foundation | £5,000 | Next round |
+| 🔴 ASAP | Coalfields Regeneration Trust | £10,000 | Rolling |
+| 🟠 Soon | Tudor Trust | £50,000 | Rolling |
+| 🟠 Soon | Henry Smith Charity | £100,000 | Rolling |
+| 🟠 Soon | Evan Cornish Foundation | £15,000 | Rolling |
+| 🟡 Plan | Lloyds Bank Foundation | £75,000 | Check dates |
+| 🟡 Plan | NLCF – Reaching Communities | £500,000 | Rolling |
+| 🟡 Plan | Morrisons Foundation | £25,000 | Rolling |
+
+---
+
+## Application Tips
+
+1. **Lead with Trussell Trust affiliation** — it's a nationally recognised quality mark and builds instant credibility
+2. **Gather impact data** — number of households served per month, % families with children, referral agencies used
+3. **Define core costs clearly** — break down exactly what you're asking for (e.g., 1x coordinator salary, warehouse rent, van fuel)
+4. **Local connections matter** — mention Chesterfield, Derbyshire, local deprivation statistics (use Index of Multiple Deprivation data)
+5. **Stack funding** — most funders allow you to apply to multiple sources simultaneously; aim for 4–6 applications running at once
+6. **Coalfields angle** — Chesterfield's mining heritage is a genuine differentiator for Coalfields Regeneration Trust and similar
+7. **Church partnership** — if any local churches host/support the foodbank, it unlocks Benefact Trust and Rank Foundation
+
+---
+
+*Document created: March 2026 | Review and update deadlines quarterly*


### PR DESCRIPTION
## 📋 Funding Document for Chesterfield Trussell Trust Foodbank

Adds `funding.md` — a prioritised list of the **top 30 UK grant sources** for core operating costs.

### What's included
- 30 funders across 3 priority tiers
- Each entry has: website, amount, requirements, deadline info, and realistic chance of success rating ⭐
- Quick-win summary table for the top 10 immediate applications
- Application tips tailored to Trussell Trust affiliation + Chesterfield/Derbyshire geography

### Top picks (apply immediately)
| Funder | Amount | Why |
|--------|--------|-----|
| NLCF Awards for All | £10k | Fastest, easiest, core costs allowed |
| Iceland Foods Foundation | £5k | Built for foodbanks |
| Derbyshire Community Foundation | £5k | Local geography match |
| Coalfields Regeneration Trust | £10k | Chesterfield mining heritage = strong fit |
| Tudor Trust | £50k | Explicitly funds core costs |

---
*Review quarterly to update deadlines and add new programmes.*